### PR TITLE
Query readings by device name to fetch latest reading

### DIFF
--- a/TAF/testCaseModules/keywords/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/coreDataAPI.robot
@@ -13,9 +13,9 @@ ${coreDataValueDescriptorUri}   /api/v1/valuedescriptor
 *** Keywords ***
 Device reading should be sent to Core Data
     [Arguments]     ${data_type}    ${reading_name}    ${set_reading_value}
-    ${device_reading_data}=  Query device reading "${reading_name}" by device id
-    ${device_reading_json}=    evaluate  json.loads('''${device_reading_data}''')  json
-    ${result}=  check value equal  ${data_type}  ${set_reading_value}   ${device_reading_json}[0][value]
+    ${device_name}=  Query device by id and return device name
+    ${device_reading_data}=  Query device reading by device name "${deviceName}"
+    ${result}=  check value equal  ${data_type}  ${set_reading_value}   ${device_reading_data}[0][value]
     should be true  ${result}
 
 

--- a/docs/edgex-taf.rst
+++ b/docs/edgex-taf.rst
@@ -150,6 +150,8 @@ Modify the protocol properties of xxx_device.json, the property key and value ar
 
 In this document, we deploy all services using docker, so we must add the docker images to the docker-compose file, as illustrated below::
 
+  # TAF/utils/scripts/docker/device-service.yaml
+
   device-virtual:
     image: edgexfoundry/docker-device-virtual-go:1.0.0
     ports:
@@ -178,25 +180,36 @@ In this document, we deploy all services using docker, so we must add the docker
 5. Run testing
 ---------------
 Navigate to the edgex-taf root path and Run the tests using the following commands::
-1.Deploy edgex::
+
+1.Prepare test environment::
+
+        # Fetch the latest docker-compose file
+        cd path/to/edgex-taf/TAF/utils/scripts/docker/
+        ./get-compose-file.sh
+
+        # export the environment variable which depend on your machine
+        cd path/to/edgex-taf
+        export ARCH=x86_64
+
+2.Deploy edgex::
 
         python3 -m TUC -p device-virtual -t functionalTest/deploy-edgex.robot
 
-2.Deploy DS::
+3.Deploy DS::
 
         python3 -m TUC -p device-virtual -t functionalTest/device-service/deploy_device_service.robot
 
-3.Run DS testing::
+4.Run DS testing::
 
         python3 -m TUC -p device-virtual -u functionalTest/device-service/common
 
-4. Open the Test Reports
+5. Open the Test Reports
 
 Open the test reports in the browser. For example, to open the virtual DS testing report, enter the following URL in the browser::
 
     path/to/edgex-taf/TAF/testArtifacts/reports/edgex/report.html
 
-5.Shutdown edgex::
+6.Shutdown edgex::
 
     python3 -m TUC -p device-virtual -t functionalTest/shutdown.robot
 


### PR DESCRIPTION
TAF needs to fetch the newest reading to verify the write command execution is correct.

Fix #44 