### PR TITLE
Create test cases for adding reading

### DIFF
--- a/TAF/testCaseModules/keywords/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/coreDataAPI.robot
@@ -93,7 +93,7 @@ Query readings by value descriptor ${valueDescriptor} and device id "${deviceId}
     @{readings}=  evaluate  json.loads('''${resp.content}''')  json
     [Return]   @{readings}
 
-Add reading with value ${value} by value descriptor ${valueDescriptor} and device id "${deviceId}"
+Add reading with value ${value} by value descriptor ${valueDescriptor} and device id ${deviceId}
     Create Session  Core Data  url=${coreDataUrl}
     ${data}=    Create Dictionary   device=${deviceId}   name=${valueDescriptor}    value=${value}
     ${headers}=  Create Dictionary  Content-Type=application/json

--- a/TAF/testCaseModules/keywords/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/coreDataAPI.robot
@@ -99,4 +99,4 @@ Add reading with value ${value} by value descriptor ${valueDescriptor} and devic
     ${headers}=  Create Dictionary  Content-Type=application/json
     ${resp}=  Post Request  Core Data    ${coreDataReadingUri}  json=${data}   headers=${headers}
     run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
-    Should Be Equal As Strings  ${resp.status_code}  200
+    Set test variable  ${response}  ${resp.status_code}

--- a/TAF/testCaseModules/keywords/coreMetadataAPI.robot
+++ b/TAF/testCaseModules/keywords/coreMetadataAPI.robot
@@ -22,6 +22,13 @@ Create device profile
     Should Be Equal As Strings  ${resp.status_code}  200
     set suite variable  ${deviceProfileId}  ${resp.content}
 
+Create device profile ${entity}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${headers}=  Create Dictionary  Content-Type=application/json
+    ${resp}=  Post Request  Core Metadata    /api/v1/deviceprofile  json=${entity}   headers=${headers}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Set test variable  ${response}  ${resp.status_code}
+
 Query device profile by id and return by device profile name
     Create Session  Core Metadata  url=${coreMetadataUrl}
     ${resp}=   get request  Core Metadata    ${deviceProfileUri}/${deviceProfileId}
@@ -48,6 +55,12 @@ Delete device profile by name
     run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
     Should Be Equal As Strings  ${resp.status_code}  200
 
+Delete device profile by name ${device_profile_name}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${resp}=  Delete Request  Core Metadata  ${deviceProfileUri}/name/${device_profile_name}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
 # Device
 Create device
     [Arguments]  ${device_file}
@@ -59,6 +72,13 @@ Create device
     run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
     Should Be Equal As Strings  ${resp.status_code}  200
     set suite variable  ${device_id}   ${resp.content}
+
+Create device with ${entity}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${headers}=  Create Dictionary  Content-Type=application/json
+    ${resp}=  Post Request  Core Metadata    ${deviceUri}  json=${entity}   headers=${headers}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Set test variable  ${response}  ${resp.status_code}
 
 Creat device with autoEvents parameter
     [Arguments]  ${frequency_time}  ${onChange_value}  ${reading_name}
@@ -91,6 +111,12 @@ Delete device by name
     run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
     Should Be Equal As Strings  ${resp.status_code}  200
 
+Delete device by name ${deviceName}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${resp}=  Delete Request  Core Metadata  ${deviceUri}/name/${deviceName}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
 Create device profile and device
     ${status} =  Suite Setup  ${SUITE}  ${LOG_FILE_PATH}  ${LOG_LEVEL}
     Should Be True  ${status}  Failed Suite Setup
@@ -98,5 +124,30 @@ Create device profile and device
     Create device   create_device.json
 
 
+# Addressable
+Create addressable ${entity}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${headers}=  Create Dictionary  Content-Type=application/json
+    ${resp}=  Post Request  Core Metadata    /api/v1/addressable  json=${entity}   headers=${headers}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Set test variable  ${response}  ${resp.status_code}
 
+Delete addressable by name ${addressableName}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${resp}=  Delete Request  Core Metadata  api/v1/addressable/name/${addressableName}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Should Be Equal As Strings  ${resp.status_code}  200
 
+# Device service
+Create device service ${entity}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${headers}=  Create Dictionary  Content-Type=application/json
+    ${resp}=  Post Request  Core Metadata    /api/v1/deviceservice  json=${entity}   headers=${headers}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Set test variable  ${response}  ${resp.status_code}
+
+Delete device service by name ${deviceServiceName}
+    Create Session  Core Metadata  url=${coreMetadataUrl}
+    ${resp}=  Delete Request  Core Metadata  api/v1/deviceservice/name/${deviceServiceName}
+    run keyword if  ${resp.status_code}!=200  log to console  ${resp.content}
+    Should Be Equal As Strings  ${resp.status_code}  200

--- a/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
+++ b/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation  Device Readings - Query readings
+Library   OperatingSystem
+Library   Collections
+Resource  TAF/testCaseModules/keywords/commonKeywords.robot
+Resource  TAF/testCaseModules/keywords/coreDataAPI.robot
+
+
+
+*** Variables ***
+${SUITE}                                  Add Reading
+${READINGS}
+${DEVICE_ADD_READING}                device-add-reading
+${DEVICE_ADD_READING_VALUE_DESCRIPTOR}    device-add-reading-value-descriptor
+${DEVICE_ADD_READING_VALUE}    123
+
+
+
+*** Keywords ***
+Query readings by value descriptor and device id
+    [Arguments]    ${valueDescriptor}   ${deviceId}
+    ${readings}=  Query readings by value descriptor ${valueDescriptor} and device id "${deviceId}"
+    set suite variable  ${READINGS}  ${readings}
+
+Readings should contain the value descriptor and device id and value
+    [Arguments]    ${valueDescriptor}   ${deviceId}   ${value}
+        ${length}=  get length  ${READINGS}
+    :FOR    ${reading}   IN  @{READINGS}
+    \  Should contain      ${reading}[name]  ${valueDescriptor}
+    \  Should contain      ${reading}[device]  ${deviceId}
+    \  Should contain      ${reading}[value]  ${value}
+
+*** Test Cases ***
+Add reading to core data srevice
+    When add reading with value ${DEVICE_ADD_READING_VALUE} by value descriptor ${DEVICE_ADD_READING_VALUE_DESCRIPTOR} and device id ${DEVICE_ADD_READING}
+    Then query readings by value descriptor and device id   ${DEVICE_ADD_READING_VALUE_DESCRIPTOR}  ${DEVICE_ADD_READING}
+    And readings should contain the value descriptor and device id and value   ${DEVICE_ADD_READING_VALUE_DESCRIPTOR}  ${DEVICE_ADD_READING}  ${DEVICE_ADD_READING_VALUE}

--- a/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
+++ b/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
@@ -2,36 +2,78 @@
 Documentation  Device Readings - Query readings
 Library   OperatingSystem
 Library   Collections
+Library   TAF.utils.src.setup.consul
 Resource  TAF/testCaseModules/keywords/commonKeywords.robot
 Resource  TAF/testCaseModules/keywords/coreDataAPI.robot
-
+Resource  TAF/testCaseModules/keywords/coreMetadataAPI.robot
+Suite Setup  Setup Suite
 
 
 *** Variables ***
-${SUITE}                                  Add Reading
+${SUITE}                        Add Reading
 ${READINGS}
-${DEVICE_ADD_READING}                device-add-reading
-${DEVICE_ADD_READING_VALUE_DESCRIPTOR}    device-add-reading-value-descriptor
-${DEVICE_ADD_READING_VALUE}    123
+${TEST_DEVICE_1}                test-device-1
+${TEST_DEVICE_1_VALUE_DESCRIPTOR}    test-device-1-value-descriptor
+${TEST_DEVICE_1_VALUE}    123
+${TEST_DEVICE_2}                test-device-2
+${TEST_DEVICE_2_VALUE_DESCRIPTOR}    test-device-2-value-descriptor
+${TEST_DEVICE_2_VALUE}    123
 
-
+${TEST_DEVICE_3}=
+...  {
+...    "name" :"test-device-3","adminState":"UNLOCKED","operatingState":"ENABLED",
+...    "service":{"name":"Test-Device-Service"},
+...    "profile": {"name": "Test-Device-Profile"},
+...    "protocols":{"other": {}}
+...  }
+${TEST_DEVICE_3_VALUE_DESCRIPTOR}    test-device-3-value-descriptor
+${TEST_DEVICE_3_VALUE}    123
 
 *** Keywords ***
 Query readings by value descriptor and device id
     [Arguments]    ${valueDescriptor}   ${deviceId}
     ${readings}=  Query readings by value descriptor ${valueDescriptor} and device id "${deviceId}"
-    set suite variable  ${READINGS}  ${readings}
+    Set test variable  ${READINGS}  ${readings}
 
 Readings should contain the value descriptor and device id and value
     [Arguments]    ${valueDescriptor}   ${deviceId}   ${value}
         ${length}=  get length  ${READINGS}
     :FOR    ${reading}   IN  @{READINGS}
-    \  Should contain      ${reading}[name]  ${valueDescriptor}
-    \  Should contain      ${reading}[device]  ${deviceId}
-    \  Should contain      ${reading}[value]  ${value}
+    \  Should contain    ${reading}[name]  ${valueDescriptor}
+    \  Should contain    ${reading}[device]  ${deviceId}
+    \  Should contain    ${reading}[value]  ${value}
+
+The config MetaDataCheck set to ${boolVal}
+    Modify consul config  /v1/kv/edgex/core/1.0/edgex-core-data/Writable/MetaDataCheck  ${boolVal}
+    sleep  2
 
 *** Test Cases ***
 Add reading to core data srevice
-    When add reading with value ${DEVICE_ADD_READING_VALUE} by value descriptor ${DEVICE_ADD_READING_VALUE_DESCRIPTOR} and device id ${DEVICE_ADD_READING}
-    Then query readings by value descriptor and device id   ${DEVICE_ADD_READING_VALUE_DESCRIPTOR}  ${DEVICE_ADD_READING}
-    And readings should contain the value descriptor and device id and value   ${DEVICE_ADD_READING_VALUE_DESCRIPTOR}  ${DEVICE_ADD_READING}  ${DEVICE_ADD_READING_VALUE}
+    When add reading with value ${TEST_DEVICE_1_VALUE} by value descriptor ${TEST_DEVICE_1_VALUE_DESCRIPTOR} and device id ${TEST_DEVICE_1}
+    Then query readings by value descriptor and device id   ${TEST_DEVICE_1_VALUE_DESCRIPTOR}  ${TEST_DEVICE_1}
+    And readings should contain the value descriptor and device id and value   ${TEST_DEVICE_1_VALUE_DESCRIPTOR}  ${TEST_DEVICE_1}  ${TEST_DEVICE_1_VALUE}
+
+Fail to add reading to core data srevice when the config MetaDataCheck set to true
+    Given the config MetaDataCheck set to true
+    When add reading with value ${TEST_DEVICE_2_VALUE} by value descriptor ${TEST_DEVICE_2_VALUE_DESCRIPTOR} and device id ${TEST_DEVICE_2}
+    Then should return status code "400"
+    [Teardown]  the config MetaDataCheck set to false
+
+# Adding reading needs the device data when the config MetaDataCheck set to true
+Success to add reading to core data srevice when the config MetaDataCheck set to true
+    ${addressable}=    Create Dictionary   name=test-addressable
+    ${deviceService}=    Create Dictionary   name=Test-Device-Service  adminState=UNLOCKED  operatingState=ENABLED  addressable=${addressable}
+    ${deviceProfile}=    Create Dictionary   name=Test-Device-Profile
+    ${device}=  evaluate  json.loads('''${TEST_DEVICE_3}''')  json
+    Given the config MetaDataCheck set to true
+    And create addressable ${addressable}
+    And create device service ${deviceService}
+    And create device profile ${deviceProfile}
+    And create device with ${device}
+    When add reading with value ${TEST_DEVICE_3_VALUE} by value descriptor ${TEST_DEVICE_3_VALUE_DESCRIPTOR} and device id ${device}[name]
+    Then should return status code "200"
+    [Teardown]  Run Keywords  the config MetaDataCheck set to false
+    ...  AND  delete device by name ${device}[name]
+    ...  AND  delete device profile by name ${deviceProfile}[name]
+    ...  AND  delete device service by name ${deviceService}[name]
+    ...  AND  delete addressable by name ${addressable}[name]

--- a/TAF/testScenarios/functionalTest/core-data/UC_readings/query_reading.robot
+++ b/TAF/testScenarios/functionalTest/core-data/UC_readings/query_reading.robot
@@ -4,7 +4,7 @@ Library   OperatingSystem
 Library   Collections
 Resource  TAF/testCaseModules/keywords/coreDataAPI.robot
 Resource  TAF/testCaseModules/keywords/commonKeywords.robot
-
+Suite Setup  Setup Suite
 
 *** Variables ***
 ${SUITE}                                  Query Readings

--- a/docs/edgex-taf.rst
+++ b/docs/edgex-taf.rst
@@ -336,3 +336,16 @@ Run DS testing as follows
         -v /var/run/docker.sock:/var/run/docker.sock \
         docker-edgex-taf-common \
         -p device-virtual -t functionalTest/shutdown.robot
+
+
+Run CoreData Testing
+====================
+
+1.Deploy edgex::
+
+        python3 -m TUC -p core-data -t functionalTest/deploy-edgex.robot
+
+2.Run testing::
+
+        python3 -m TUC -p core-data -u functionalTest/core-data
+


### PR DESCRIPTION
Fix #17 

Add test cases:
- Fail to add reading to core data srevice when the config MetaDataCheck set to true
- Success to add reading to core data srevice when the config MetaDataCheck set to true