### PR TITLE
Add robot file for support-scheduler

### DIFF
--- a/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
+++ b/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Resource  TAF/testCaseModules/keywords/coreMetadataAPI.robot
+Default Tags  skipped
+
+*** Variables ***
+${SUITE}         Clean Up Events/Readings By Scheduler
+
+
+*** Keywords ***
+
+
+*** Test Cases ***
+Scheduler001-Set scheduler for each 30s to clean up events
+    Given Create Interval and set frequency to "30s"
+    When Create interval action with delete events for core-data
+    sleep  30
+    Then All events have been deleted
+
+Scheduler002-Set scheduler for each 60s to clean up events
+    Given Create Interval and set frequency to "60s"
+    When Create interval action with delete events for core-data
+    sleep  60
+    Then All events have been deleted
+


### PR DESCRIPTION
1. clean_up_events_and_readings.robot: Call delete events/readings API to clean up events/readings.
2. clean_up_logging.robot: Call delete log API to delete log by parameter.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
fix #55 