### PR TITLE
Fix modbus simulator error

### DIFF
--- a/TAF/config/device-modbus/create_autoevent_device.json
+++ b/TAF/config/device-modbus/create_autoevent_device.json
@@ -6,8 +6,8 @@
    "operatingState":"ENABLED",
    "protocols":{
       "modbus-tcp":{
-         "Address"  : "172.17.0.1",
-         "Port" : "502",
+         "Address"  : "edgex-modbus-simulator",
+         "Port" : "1502",
          "UnitID": "1"
       }
    },

--- a/TAF/config/device-modbus/create_disabled_device.json
+++ b/TAF/config/device-modbus/create_disabled_device.json
@@ -6,8 +6,8 @@
    "operatingState":"DISABLED",
    "protocols":{
       "modbus-tcp":{
-         "Address"  : "172.17.0.1",
-         "Port" : "502",
+         "Address"  : "edgex-modbus-simulator",
+         "Port" : "1502",
          "UnitID": "1"
       }
    },

--- a/TAF/config/device-modbus/create_locked_device.json
+++ b/TAF/config/device-modbus/create_locked_device.json
@@ -6,8 +6,8 @@
    "operatingState":"ENABLED",
    "protocols":{
       "modbus-tcp":{
-         "Address"  : "172.17.0.1",
-         "Port" : "502",
+         "Address"  : "edgex-modbus-simulator",
+         "Port" : "1502",
          "UnitID": "1"
       }
    },

--- a/TAF/utils/scripts/docker/device-service.yaml
+++ b/TAF/utils/scripts/docker/device-service.yaml
@@ -100,4 +100,6 @@
     hostname: edgex-modbus-simulator
     ports:
      - "1502:1502"
+    networks:
+      - edgex-network
 


### PR DESCRIPTION
Create device and protocol point to modbus simulator container, not docker host.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
fix #72 