### PR TITLE
Update scripts for taf-pipeline backward testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ TAF/testArtifacts/logs/*
 TAF/testArtifacts/reports/*
 TAF-Common/*
 TAF/utils/scripts/docker/*.yml*
-TAF/utils/scripts/docker/docker-compose.yaml
-TAF/utils/scripts/docker/docker-compose-backward.yaml
+TAF/utils/scripts/docker/docker-compose*yaml*

--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -44,5 +44,6 @@ fi
 docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
         --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE}  \
         --env DS_PROFILE=${DS_PROFILE} --env CONF_DIR=${CONF_DIR} --env REGISTRY_URL=${REGISTRY_URL} \
-        ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d consul data metadata command logging notifications scheduler
+        ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${BACKWARD}.yaml" up -d consul data metadata command logging notifications scheduler
 sleep 5
+

--- a/TAF/utils/scripts/docker/get-compose-file-backward.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-backward.sh
@@ -1,11 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-USE_DB=$1
-ARCH=$2
-USE_SECURITY=$3
-
-# # default redis DB
-USE_DB=${USE_DB:--redis}
+# # set default values
+USE_DB=${1:--redis}
+USE_ARCH=${2:--x86_64}
+USE_SECURITY=${3:--}
+USE_RELEASE=${4:-fuji}
 
 # # security or no security
 [ "$USE_SECURITY" != '-security-' ] && USE_NO_SECURITY="-no-secty"
@@ -24,6 +23,7 @@ wget -O temp/fuji-compose.yaml "https://raw.githubusercontent.com/edgexfoundry/d
 sed -n '/x-common-env-variables/,/^volumes:/{//!p;}' temp/nb-compose.yaml > temp/env-variables.yaml
 sed -n '/metadata:/,/scheduler:/{//!p;}' temp/nb-compose.yaml > temp/core-services.yaml
 sed -n '/- edgex-device-virtual/,/device-random:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+sed -i -r 's/kong:1.3.0$/kong:1.3.0-centos/' temp/fuji-compose.yaml
 sed -n \
     -e '1,/x-common-env-variables/ p' \
     -e '/x-common-env-variables/ r temp/env-variables.yaml' \

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-USE_DB=$1
-USE_ARCH=$2
-USE_SECURITY=$3
-
 # # set default values
-USE_DB=${USE_DB:--redis}
-USE_ARCH=${USE_ARCH:--x86_64}
-USE_SECURITY=${USE_SECURITY:--}
+USE_DB=${1:--redis}
+USE_ARCH=${2:--x86_64}
+USE_SECURITY=${3:--}
+USE_RELEASE=${4:-nightly-build}
 
 # # x86_64 or arm64
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64"
@@ -15,30 +12,38 @@ USE_SECURITY=${USE_SECURITY:--}
 # # security or no security
 [ "$USE_SECURITY" != '-security-' ] && USE_NO_SECURITY="-no-secty"
 
-# nightly or other release
-USE_RELEASE=${RELEASE:-nightly-build}
+# # nightly or other release
 if [ "$USE_RELEASE" = "nightly-build" ]; then
      COMPOSE_FILE="docker-compose-nexus${USE_DB}${USE_NO_SECURITY}${USE_ARM64}.yml"
+     wget -O ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/${COMPOSE_FILE}"
+
+     # Delete device-virtual service from the compose file
+     sed -i -r '/device-virtual:/,/- command/ {/ / d;}' ${COMPOSE_FILE}
+
+    # Insert device services into the compose file
+    sed -e '/# device-random:/r docker-compose-device-service.yaml' -e //N ${COMPOSE_FILE} > docker-compose-temp.yaml
+
+    # Insert required services for end to end tests
+    sed -e '/portainer:/r docker-compose-end-to-end.yaml' -e //N docker-compose-temp.yaml > docker-compose.yaml
+
 else
-     COMPOSE_FILE="docker-compose${USE_DB}${USE_RELEASE}${USE_NO_SECURITY}${USE_ARM64}.yml"
+     [ "$USE_DB" = "-mongo" ] && USE_DB=""
+     COMPOSE_FILE="docker-compose${USE_DB}-${USE_RELEASE}${USE_NO_SECURITY}${USE_ARM64}.yml"
+     wget -O ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/${USE_RELEASE}/compose-files/${COMPOSE_FILE}"
+
+     mkdir temp
+     cp ${COMPOSE_FILE} temp/docker-compose-temp.yaml
+     # Use Centos base image instead of Alpine base image for Kong for x86_64 CI
+     # due to compatibility issues with Alpine image in CI
+     sed -i -r 's/kong:1.3.0$/kong:1.3.0-centos/' temp/docker-compose-temp.yaml
+     sed -n '/- edgex-device-virtual/,/device-random:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+     sed -n \
+         -e '1,/- edgex-device-virtual/ p' \
+         -e '/- edgex-device-virtual/ r temp/device-virtual.yaml' \
+         -e '/# device-random:/,$ p' \
+         temp/docker-compose-temp.yaml > docker-compose.yaml
+     rm -rf temp
 fi
 
-wget -O ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/${USE_RELEASE}/compose-files/${COMPOSE_FILE}"
 
-# Use Centos base image instead of Alpine base image for Kong for x86_64 CI
-# due to compatibility issues with Alpine image in CI
-# sed command of MacOS is in different syntax
-if [ "$(uname -m)" = "x86_64" ] && [ "$(uname)" = "Darwin" ]; then
-     sed -i '' 's/kong:1.3.0$/kong:1.3.0-centos/' ${COMPOSE_FILE}
-elif [ "$(uname -m)" = "x86_64" ]; then
-     sed -i 's/kong:1.3.0$/kong:1.3.0-centos/' ${COMPOSE_FILE}
-fi
 
-# Delete device-virtual service from the compose file
-sed -i -r '/device-virtual:/,/- command/ {/ / d;}' ${COMPOSE_FILE}
-
-# Insert device services into the compose file
-sed -e '/# device-random:/r docker-compose-device-service.yaml' -e //N ${COMPOSE_FILE} > docker-compose-temp.yaml
-
-# Insert required services for end to end tests
-sed -e '/portainer:/r docker-compose-end-to-end.yaml' -e //N docker-compose-temp.yaml > docker-compose.yaml


### PR DESCRIPTION
Fix https://github.com/edgexfoundry/edgex-taf/issues/69

- add the missing ${BACKWARD} in docker-compose.yaml
- update scripts to get fuji compose file correctly for backward testing


Signed-off-by: Ginny Guan <ginny@iotechsys.com>