### PR TITLE
Support device service for fuji release

### DIFF
--- a/TAF/config/device-virtual/fuji/configuration.toml
+++ b/TAF/config/device-virtual/fuji/configuration.toml
@@ -1,0 +1,55 @@
+[Service]
+Host = "edgex-device-virtual"
+Port = 49990
+ConnectRetries = 3
+Labels = []
+OpenMsg = "device virtual started"
+Timeout = 5000
+EnableAsyncReadings = true
+AsyncBufferSize = 16
+
+[Registry]
+Type = "consul"
+Host = "edgex-core-consul"
+Port = 8500
+CheckInterval = "10s"
+FailLimit = 3
+FailWaitTime = 10
+
+[Logging]
+EnableRemote = false
+File = ""
+
+[Writable]
+LogLevel = 'INFO'
+
+[Clients]
+  [Clients.Data]
+  Name = "edgex-core-data"
+  Protocol = "http"
+  Host = "edgex-core-data"
+  Port = 48080
+  Timeout = 5000
+
+  [Clients.Metadata]
+  Name = "edgex-core-metadata"
+  Protocol = "http"
+  Host = "edgex-core-metadata"
+  Port = 48081
+  Timeout = 5000
+
+  [Clients.Logging]
+  Name = "edgex-support-logging"
+  Protocol = "http"
+  Host = "edgex-support-logging"
+  Port = 48061
+
+[Device]
+  DataTransform = true
+  InitCmd = ""
+  InitCmdArgs = ""
+  MaxCmdOps = 128
+  MaxCmdValueLen = 256
+  RemoveCmd = ""
+  RemoveCmdArgs = ""
+  ProfilesDir = "/custom-config"

--- a/TAF/utils/scripts/docker/docker-compose-device-service.yaml
+++ b/TAF/utils/scripts/docker/docker-compose-device-service.yaml
@@ -4,8 +4,6 @@
     - "49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
-    entrypoint: ["/device-virtual"]
-    command: ["--registry","--confdir=${CONF_DIR}", "--profile=${DS_PROFILE}"]
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
@@ -18,6 +16,11 @@
     depends_on:
       - data
       - command
+    entrypoint:
+      - /device-virtual
+      - --registry
+      - --confdir=${CONF_DIR}
+      - --profile=${DS_PROFILE}
 
   edgex-device-modbus:
     image: ${modbus}

--- a/TAF/utils/scripts/docker/get-compose-file-backward.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-backward.sh
@@ -22,7 +22,14 @@ wget -O temp/fuji-compose.yaml "https://raw.githubusercontent.com/edgexfoundry/d
 # replace fuji core services with nightly-build core services
 sed -n '/x-common-env-variables/,/^volumes:/{//!p;}' temp/nb-compose.yaml > temp/env-variables.yaml
 sed -n '/metadata:/,/scheduler:/{//!p;}' temp/nb-compose.yaml > temp/core-services.yaml
-sed -n '/- edgex-device-virtual/,/device-random:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+sed -n '/- edgex-device-virtual/,/edgex-device-modbus:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+
+# Replace the parameter when using fuji device-virtual
+if [ "$USE_RELEASE" = "fuji" ]; then
+    sed -i.bak 's/--registry/--registry=consul:\/\/edgex-core-consul:8500/' temp/device-virtual.yaml
+    sed -i.bak "s/\${DS_PROFILE}/${USE_RELEASE}/" temp/device-virtual.yaml
+fi
+
 sed -i -r 's/kong:1.3.0$/kong:1.3.0-centos/' temp/fuji-compose.yaml
 sed -n \
     -e '1,/x-common-env-variables/ p' \

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -13,37 +13,42 @@ USE_RELEASE=${4:-nightly-build}
 [ "$USE_SECURITY" != '-security-' ] && USE_NO_SECURITY="-no-secty"
 
 # # nightly or other release
+mkdir temp
 if [ "$USE_RELEASE" = "nightly-build" ]; then
      COMPOSE_FILE="docker-compose-nexus${USE_DB}${USE_NO_SECURITY}${USE_ARM64}.yml"
      wget -O ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/${COMPOSE_FILE}"
 
+     cp ${COMPOSE_FILE} temp/docker-compose-temp.yaml
      # Delete device-virtual service from the compose file
-     sed -i -r '/device-virtual:/,/- command/ {/ / d;}' ${COMPOSE_FILE}
+     sed -i -r '/device-virtual:/,/- command/ {/ / d;}' temp/docker-compose-temp.yaml
 
     # Insert device services into the compose file
-    sed -e '/# device-random:/r docker-compose-device-service.yaml' -e //N ${COMPOSE_FILE} > docker-compose-temp.yaml
+    sed -e '/# device-random:/r docker-compose-device-service.yaml' -e //N temp/docker-compose-temp.yaml > temp/device-service-temp.yaml
 
     # Insert required services for end to end tests
-    sed -e '/portainer:/r docker-compose-end-to-end.yaml' -e //N docker-compose-temp.yaml > docker-compose.yaml
+    sed -e '/portainer:/r docker-compose-end-to-end.yaml' -e //N temp/device-service-temp.yaml > docker-compose.yaml
 
 else
      [ "$USE_DB" = "-mongo" ] && USE_DB=""
      COMPOSE_FILE="docker-compose${USE_DB}-${USE_RELEASE}${USE_NO_SECURITY}${USE_ARM64}.yml"
      wget -O ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/${USE_RELEASE}/compose-files/${COMPOSE_FILE}"
 
-     mkdir temp
+
      cp ${COMPOSE_FILE} temp/docker-compose-temp.yaml
      # Use Centos base image instead of Alpine base image for Kong for x86_64 CI
      # due to compatibility issues with Alpine image in CI
      sed -i -r 's/kong:1.3.0$/kong:1.3.0-centos/' temp/docker-compose-temp.yaml
-     sed -n '/- edgex-device-virtual/,/device-random:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+     sed -n '/- edgex-device-virtual/,/edgex-device-modbus:/{//!p;}' docker-compose-device-service.yaml > temp/device-virtual.yaml
+
+     if [ "$USE_RELEASE" = "fuji" ]; then
+       sed -i.bak 's/--registry/--registry=consul:\/\/edgex-core-consul:8500/' temp/device-virtual.yaml
+       sed -i.bak "s/\${DS_PROFILE}/${USE_RELEASE}/" temp/device-virtual.yaml
+     fi
+
      sed -n \
          -e '1,/- edgex-device-virtual/ p' \
          -e '/- edgex-device-virtual/ r temp/device-virtual.yaml' \
          -e '/# device-random:/,$ p' \
          temp/docker-compose-temp.yaml > docker-compose.yaml
-     rm -rf temp
 fi
-
-
-
+rm -rf temp


### PR DESCRIPTION
1. Update docker-compose to support both release, fuji and geneva.
2. Create a new configuration.toml for fuji release. 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>