### PR TITLE
fix: Fixed links to nightly-build compose files to point to edgexfoundry master

### DIFF
--- a/TAF/utils/scripts/docker/get-compose-file-backward.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-backward.sh
@@ -6,8 +6,7 @@ USE_ARCH=${2:--x86_64}
 USE_SECURITY=${3:--}
 USE_RELEASE=${4:-geneva}
 
-# TODO: Change URl and file spec to use edgexfoundry master once developer-scripts PR is merged
-NIGHTLY_BUILD_SOURCE_URL="https://raw.githubusercontent.com/lenny-intel/developer-scripts/multi2/releases/nightly-build/compose-files/source"
+NIGHTLY_BUILD_SOURCE_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/source"
 
 # # x86_64 or arm64
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64" && ARM64_OPTION="arm64"

--- a/TAF/utils/scripts/docker/sync-nightly-build.sh
+++ b/TAF/utils/scripts/docker/sync-nightly-build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# TODO: Change URl and file spec to use edgexfoundry master once developer-scripts PR is merged
-NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/lenny-intel/developer-scripts/multi2/releases/nightly-build/compose-files"
+NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files"
 
 # x86_64 or arm64
 [ "$(uname -m)" != "x86_64" ] && USE_ARM64="-arm64"


### PR DESCRIPTION

Just fix the links to properly point to nightly-build compose files in master and not Lenny's branch