### PR TITLE
For loop header ':FOR' is deprecated to use 'FOR' instead

### DIFF
--- a/TAF/testCaseModules/keywords/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/commonKeywords.robot
@@ -13,30 +13,34 @@ Setup Suite
 
 Skip write only commands
     @{data_types_skip_write_only}=    Create List
-    :FOR    ${item}    IN    @{SUPPORTED_DATA_TYPES}
-    \     Continue For Loop If   '${item["readWrite"]}' == 'W'
-    \     Append To List    ${data_types_skip_write_only}    ${item}
+    FOR    ${item}    IN    @{SUPPORTED_DATA_TYPES}
+          Continue For Loop If   '${item["readWrite"]}' == 'W'
+          Append To List    ${data_types_skip_write_only}    ${item}
+    END
     [Return]   ${data_types_skip_write_only}
 
 Skip read only commands
     @{data_types_skip_read_only}=    Create List
-    :FOR    ${item}    IN    @{SUPPORTED_DATA_TYPES}
-    \     Continue For Loop If   '${item["readWrite"]}' == 'R'
-    \     Append To List    ${data_types_skip_read_only}    ${item}
+    FOR    ${item}    IN    @{SUPPORTED_DATA_TYPES}
+          Continue For Loop If   '${item["readWrite"]}' == 'R'
+          Append To List    ${data_types_skip_read_only}    ${item}
+    END
     [Return]  ${data_types_skip_read_only}
 
 Skip data types BOOL and STRING only commands "${SUPPORTED_DATA}"
     @{data_types_skip_bool_string}=    Create List
-    :FOR    ${item}    IN    @{SUPPORTED_DATA}
-    \     Continue For Loop If   '${item["dataType"]}' == 'BOOL' or '${item["dataType"]}' == 'STRING'
-    \     Append To List    ${data_types_skip_bool_string}    ${item}
+    FOR    ${item}    IN    @{SUPPORTED_DATA}
+          Continue For Loop If   '${item["dataType"]}' == 'BOOL' or '${item["dataType"]}' == 'STRING'
+          Append To List    ${data_types_skip_bool_string}    ${item}
+    END
     [Return]  ${data_types_skip_bool_string}
 
 Skip read only and write only commands "${SUPPORTED_DATA}"
     @{data_types_get_rw}=    Create List
-    :FOR    ${item}    IN    @{SUPPORTED_DATA}
-    \     Continue For Loop If   '${item["readWrite"]}' == 'R' or '${item["readWrite"]}' == 'W'
-    \     Append To List    ${data_types_get_rw}    ${item}
+    FOR    ${item}    IN    @{SUPPORTED_DATA}
+          Continue For Loop If   '${item["readWrite"]}' == 'R' or '${item["readWrite"]}' == 'W'
+          Append To List    ${data_types_get_rw}    ${item}
+    END
     [Return]  ${data_types_get_rw}
 
 Get reading value with data type "${data_type}"

--- a/TAF/testCaseModules/keywords/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/coreDataAPI.robot
@@ -74,13 +74,14 @@ Device autoEvents with "${reading_name}" send by frequency setting "${frequency_
     sleep  2
     ${init_device_reading_data}=  run keyword and continue on failure  Query device reading by device name "AutoEvent-Device"
     ${init_device_reading_count}=  get length  ${init_device_reading_data}
-    :FOR    ${INDEX}    IN RANGE  1  4
-    \  sleep  ${sleep_time}s
-    \  ${end_time}=   Get current milliseconds epoch time
-    \  ${expected_device_reading_count}=  evaluate  ${init_device_reading_count} + ${INDEX}
-    \  ${device_reading_data}=  run keyword and continue on failure  Query device reading by device name "AutoEvent-Device"
-    \  ${device_reading_count}=  get length  ${device_reading_data}
-    \  run keyword and continue on failure  should be equal as integers  ${expected_device_reading_count}  ${device_reading_count}
+    FOR    ${INDEX}    IN RANGE  1  4
+       sleep  ${sleep_time}s
+       ${end_time}=   Get current milliseconds epoch time
+       ${expected_device_reading_count}=  evaluate  ${init_device_reading_count} + ${INDEX}
+       ${device_reading_data}=  run keyword and continue on failure  Query device reading by device name "AutoEvent-Device"
+       ${device_reading_count}=  get length  ${device_reading_data}
+       run keyword and continue on failure  should be equal as integers  ${expected_device_reading_count}  ${device_reading_count}
+    END
 
 Query value descriptor for name "${value_descriptor_name}"
     Create Session  Core Data  url=${coreDataUrl}  disable_warnings=true

--- a/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
+++ b/TAF/testScenarios/functionalTest/core-data/UC_readings/add_reading.robot
@@ -40,10 +40,11 @@ Query readings by value descriptor and device id
 Readings should contain the value descriptor and device id and value
     [Arguments]    ${valueDescriptor}   ${deviceId}   ${value}
         ${length}=  get length  ${READINGS}
-    :FOR    ${reading}   IN  @{READINGS}
-    \  Should contain    ${reading}[name]  ${valueDescriptor}
-    \  Should contain    ${reading}[device]  ${deviceId}
-    \  Should contain    ${reading}[value]  ${value}
+    FOR    ${reading}   IN  @{READINGS}
+       Should contain    ${reading}[name]  ${valueDescriptor}
+       Should contain    ${reading}[device]  ${deviceId}
+       Should contain    ${reading}[value]  ${value}
+    END
 
 The config MetaDataCheck set to ${boolVal}
     Modify consul config  /v1/kv/edgex/core/1.0/edgex-core-data/Writable/MetaDataCheck  ${boolVal}

--- a/TAF/testScenarios/functionalTest/core-data/UC_readings/query_reading.robot
+++ b/TAF/testScenarios/functionalTest/core-data/UC_readings/query_reading.robot
@@ -19,8 +19,9 @@ ${VALUE_DESCRIPTOR_TEST_DEVICE_1_VAL1}    test-device-1-val
 
 *** Keywords ***
 core-data has ${amount} readings with value descriptor ${valueDescriptor} and device id ${deviceId}
-    :FOR    ${INDEX}    IN RANGE  ${amount}
-    \  run keyword and continue on failure  add reading with value ${INDEX} by value descriptor ${valueDescriptor} and device id ${deviceId}
+    FOR    ${INDEX}    IN RANGE  ${amount}
+       run keyword and continue on failure  add reading with value ${INDEX} by value descriptor ${valueDescriptor} and device id "${deviceId}"
+    END
 
 Query readings by value descriptor and device id
     [Arguments]    ${valueDescriptor}   ${deviceId}
@@ -30,15 +31,17 @@ Query readings by value descriptor and device id
 Readings should order by created in descending order
     # Compare the created date to check the reading order
     ${length}=  get length  ${READINGS}
-    :FOR    ${index}   IN RANGE  0  ${length}-1
-    \  Should Be True  ${READINGS}[${index}][created] > ${READINGS}[${index+1}][created]
+    FOR    ${index}   IN RANGE  0  ${length}-1
+       Should Be True  ${READINGS}[${index}][created] > ${READINGS}[${index+1}][created]
+    END
 
 Readings should contain the value descriptor and device id
     [Arguments]    ${valueDescriptor}   ${deviceId}
         ${length}=  get length  ${READINGS}
-    :FOR    ${reading}   IN  @{READINGS}
-    \  Should contain      ${reading}[name]  ${valueDescriptor}
-    \  Should contain      ${reading}[device]  ${deviceId}
+    FOR    ${reading}   IN  @{READINGS}
+       Should contain      ${reading}[name]  ${valueDescriptor}
+       Should contain      ${reading}[device]  ${deviceId}
+    END
 
 *** Test Cases ***
 Query readings by device name and value descriptor

--- a/TAF/testScenarios/functionalTest/device-service/common/3_device_profile/3_device_profile.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/3_device_profile/3_device_profile.robot
@@ -23,14 +23,16 @@ DeviceProfile "${device_profile_name}" should be created in Core Metadata
 
 DS should create ValueDescriptors in Core Data according to DeviceProfile "${device_profile_name}"
     @{resources}=  Retrieve all resource names for the device profile "${device_profile_name}"
-    :For    ${resource_name}   IN    @{resources}
-    \   run keyword and continue on failure  Query value descriptor for name "${resource_name}"
+    FOR    ${resource_name}   IN    @{resources}
+        run keyword and continue on failure  Query value descriptor for name "${resource_name}"
+    END
 
 Retrieve all resource names for the device profile "${device_profile_name}"
     ${device_profile_content}=  Query device profile by name    ${device_profile_name}
     ${device_profile_json}=  evaluate  json.loads('''${device_profile_content}''')  json
     ${resource_length}=  get length  ${device_profile_json}[deviceResources]
     @{resource_names}=   create list
-    :For    ${INDEX}  IN RANGE  ${resource_length}
-    \   Append To List    ${resource_names}    ${device_profile_json}[deviceResources][${INDEX}][name]
+    FOR    ${INDEX}  IN RANGE  ${resource_length}
+        Append To List    ${resource_names}    ${device_profile_json}[deviceResources][${INDEX}][name]
+    END
     [Return]   ${resource_names}

--- a/TAF/testScenarios/functionalTest/device-service/common/5_query_commands/5_query_commands.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/5_query_commands/5_query_commands.robot
@@ -19,8 +19,9 @@ ${SUITE}              Query Commands
 Get001 - Test Retrieve device reading by id and the data is sent to Core Data with multiple data type
     [Tags]  Backward
     @{data_types_skip_write_only}=  Skip write only commands
-    : FOR    ${item}    IN    @{data_types_skip_write_only}
-    \  run keyword and continue on failure  Retrieve reading by device id and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    FOR    ${item}    IN    @{data_types_skip_write_only}
+       run keyword and continue on failure  Retrieve reading by device id and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    END
 
 Get002 - Test Retrieve device reading by id but the device does not exist
     [Tags]  Backward
@@ -35,8 +36,9 @@ Get003 - Test Retrieve device reading by id but the command does not exist
 Get004 - Test Retrieve device reading by name and the data is sent to Core Data with multiple data type
     [Tags]  Backward
     @{data_types_skip_write_only}=  Skip write only commands
-    : FOR    ${item}    IN    @{data_types_skip_write_only}
-    \  run keyword and continue on failure  Retrieve reading by device name and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    FOR    ${item}    IN    @{data_types_skip_write_only}
+      run keyword and continue on failure  Retrieve reading by device name and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    END
 
 Get005 - Test Retrieve device reading by name but the device does not exist
     @{data_types_skip_write_only}=  Skip write only commands
@@ -50,8 +52,9 @@ Get006 - Test Retrieve device reading by name but the command does not exist
 
 Get007 - Test Retrieve all devices data and the data is sent to Core Data
     @{data_types_skip_write_only}=  Skip write only commands
-    : FOR    ${item}    IN    @{data_types_skip_write_only}
-    \  run keyword and continue on failure  Retrieve all devices data and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    FOR    ${item}    IN    @{data_types_skip_write_only}
+       run keyword and continue on failure  Retrieve all devices data and the data is sent to Core Data  ${item["dataType"]}  ${item["commandName"]}  ${item["readingName"]}
+    END
 
 Get008 - Test Retrieve all devices data but the command does not exist
     When Invoke Get command name "invalid_command_name" for all devices
@@ -99,9 +102,10 @@ Retrieve all devices data and the data is sent to Core Data
     ${responseBody}=  Invoke Get command name "${command_name}" for all devices
     ${response_length}=  get length  ${responseBody}
     run keyword if  ${response_length} >=5  fail  "No device reading found"
-    :FOR    ${response}    IN    @{responseBody}
-    \     ${readings_length}=  get length  ${response}[readings]
-    \     sleep  500ms
-    \     ${end_time}=  Get current milliseconds epoch time
-    \     run keyword if  ${readings_length} == 0   fail  "No readings found:"+ ${response}[device]
-    \     Query device reading by start/end time  ${start_time}  ${end_time}
+    FOR    ${response}    IN    @{responseBody}
+          ${readings_length}=  get length  ${response}[readings]
+          sleep  500ms
+          ${end_time}=  Get current milliseconds epoch time
+          run keyword if  ${readings_length} == 0   fail  "No readings found:"+ ${response}[device]
+          Query device reading by start/end time  ${start_time}  ${end_time}
+    END

--- a/TAF/testScenarios/functionalTest/device-service/common/7_actuation_commands/7_actuation_commands.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/7_actuation_commands/7_actuation_commands.robot
@@ -20,8 +20,9 @@ ${SUITE}        Actuation Commands
 PUT001 - Test DS actuates commands to device/sensor by id on multiple data type
     [Tags]  Backward
     @{data_types_get_rw}=  Skip read only and write only commands "${SUPPORTED_DATA_TYPES}"
-    : FOR    ${item}    IN    @{data_types_get_rw}
-    \   run keyword and continue on failure   DS actuates commands to device/sensor by id  ${item["dataType"]}   ${item["commandName"]}  ${item["readingName"]}
+    FOR    ${item}    IN    @{data_types_get_rw}
+       run keyword and continue on failure   DS actuates commands to device/sensor by id  ${item["dataType"]}   ${item["commandName"]}  ${item["readingName"]}
+    END
 
 PUT002 - Test DS actuates commands to device/sensor by id with invalid request body
     [Tags]  Backward
@@ -47,8 +48,9 @@ PUT004 - Test DS actuates commands to device/sensor by id with invalid command
 PUT005 - Test DS actuates commands to device/sensor by name on multiple data type
     [Tags]  Backward
     @{data_types_get_rw}=  Skip read only and write only commands "${SUPPORTED_DATA_TYPES}"
-    : FOR    ${item}    IN    @{data_types_get_rw}
-    \   run keyword and continue on failure   DS actuates commands to device/sensor by name  ${item["dataType"]}   ${item["commandName"]}  ${item["readingName"]}
+    FOR    ${item}    IN    @{data_types_get_rw}
+        run keyword and continue on failure   DS actuates commands to device/sensor by name  ${item["dataType"]}   ${item["commandName"]}  ${item["readingName"]}
+    END
 
 PUT006 - Test DS actuates commands to device/sensor by name with invalid request body
     @{data_types_skip_read_only}=  Skip read only commands

--- a/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
+++ b/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
@@ -70,9 +70,10 @@ Get random command and skip write only data
     [Return]  ${random_command}
 
 Create events by get device command
-    :FOR  ${INDEX}  IN RANGE  0  5
-    \     ${random_command}=  Get random command and skip write only data
-    \     Invoke Get command by device id "${device_id}" and command name "${random_command}"
+    FOR  ${INDEX}  IN RANGE  0  5
+          ${random_command}=  Get random command and skip write only data
+          Invoke Get command by device id "${device_id}" and command name "${random_command}"
+    END
     ${status_code}  ${response_content}   Query events
     should be equal as integers  ${status_code}  200
     ${events_length}=   GET LENGTH  ${response_content}


### PR DESCRIPTION
Update the following keyword.
- For loop header ':FOR' is deprecated to use 'FOR' instead
- Marking for loop body with '\\' is deprecated. Remove markers and use 'END' instead.

Signed-off-by: Cherry Wang <cherry@iotechsys.com>
Fix #134 