### PR TITLE
Add parameter to report and fix service startup fail

### DIFF
--- a/TAF/config/performance-metrics/configuration.py
+++ b/TAF/config/performance-metrics/configuration.py
@@ -53,6 +53,6 @@ MEM_USAGE_THRESHOLD = 300
 # Loop time for retrieving CPU and Memory
 GET_CPU_MEM_LOOP_TIME = 10
 
-# Period time for retrieving CPU and Memory (in seconds)
-GET_CPU_MEM_PERIOD = 7
+# Interval time for retrieving CPU and Memory (in seconds)
+GET_CPU_MEM_INTERVAL = 7
 

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/PerformanceSummaryReports.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/PerformanceSummaryReports.py
@@ -16,25 +16,14 @@ class PerformanceSummaryReports(object):
             logger.error("Retrieve Footprint Fail")
 
         # Suite: 2_service_startup_time
-        try:
-            startup_with_creating_container
-        except NameError:
-            startup_with_creating_container = None
-
-        if startup_with_creating_container is not None:
+        if startup_with_creating_container != 'None':
             StartupTimeHandler.show_avg_max_min_in_html("Startup time aggregation with creating containers",
                                                         startup_with_creating_container)
-
         else:
             logger.error("Fail to generate startup time with creating container report")
 
-        try:
-            startup_without_creating_container
-        except NameError:
-            startup_without_creating_container = None
-
-        if startup_without_creating_container is not None:
-            StartupTimeHandler.show_avg_max_min_in_html("Startup time aggregation with creating containers",
+        if startup_without_creating_container != 'None':
+            StartupTimeHandler.show_avg_max_min_in_html("Startup time aggregation without creating containers",
                                                         startup_without_creating_container)
         else:
             logger.error("Fail to generate startup time without creating container report")

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveFootprint.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveFootprint.py
@@ -171,7 +171,8 @@ def compare_binary_footprint_size_with_prior_release(usages):
 
 def show_the_summary_table_in_html(usages):
     html = """ 
-    <h3 style="margin:0px">Resource usage:</h3>
+    <h3 style="margin:0px">Image / Executable Footprint:</h3>
+    <h4 style="margin:0px;color:blue">Threshold Setting: Geneva value * {} </h4>
     <table style="border: 1px solid black;white-space: initial;"> 
         <tr style="border: 1px solid black;">
             <th style="border: 1px solid black;">
@@ -190,7 +191,7 @@ def show_the_summary_table_in_html(usages):
                 Prior Release Executable Footprint
             </th>
         </tr>
-    """
+    """.format(SettingsInfo().profile_constant.FOOTPRINT_THRESHOLD)
 
     for k in usages:
         html = html + """ 

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveResourceUsage.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveResourceUsage.py
@@ -207,7 +207,7 @@ def calculateCPUPercentUnix(v):
 def show_the_summary_table_in_html(results):
     for res in results:
         html = """ 
-        <h3 style="margin:0px">Resource usage:</h3>
+        <h3 style="margin:0px">Full resource usage result:</h3>
         <table style="border: 1px solid black;white-space: initial;"> 
             <tr style="border: 1px solid black;">
                 <th style="border: 1px solid black;">
@@ -246,6 +246,7 @@ def show_the_summary_table_in_html(results):
 def show_the_cpu_aggregation_table_in_html(results):
     html = """ 
     <h3 style="margin:0px">CPU usage aggregation:</h3>
+    <h4 style="margin:0px;color:blue">Retrieve Resource Times: {} / Retrieve Resource Interval: {} seconds / Threshold: {}%</h4>
     <table style="border: 1px solid black;white-space: initial;"> 
         <tr style="border: 1px solid black;">
             <th style="border: 1px solid black;">
@@ -261,7 +262,9 @@ def show_the_cpu_aggregation_table_in_html(results):
                 Average
             </th>
         </tr>
-    """
+    """.format(SettingsInfo().profile_constant.GET_CPU_MEM_LOOP_TIME,
+               SettingsInfo().profile_constant.GET_CPU_MEM_INTERVAL,
+               SettingsInfo().profile_constant.CPU_USAGE_THRESHOLD)
 
     for res in results:
         html = html + """ 
@@ -290,6 +293,7 @@ def show_the_cpu_aggregation_table_in_html(results):
 def show_the_mem_aggregation_table_in_html(results):
     html = """ 
         <h3 style="margin:0px">Memory usage aggregation:</h3>
+        <h4 style="margin:0px;color:blue">Retrieve Resource Times: {} / Retrieve Resource Interval: {} seconds / Threshold: {}MB</h4>
         <table style="border: 1px solid black;white-space: initial;"> 
             <tr style="border: 1px solid black;">
                 <th style="border: 1px solid black;">
@@ -305,7 +309,9 @@ def show_the_mem_aggregation_table_in_html(results):
                     Average
                 </th>
             </tr>
-        """
+        """.format(SettingsInfo().profile_constant.GET_CPU_MEM_LOOP_TIME,
+                   SettingsInfo().profile_constant.GET_CPU_MEM_INTERVAL,
+                   SettingsInfo().profile_constant.MEM_USAGE_THRESHOLD)
 
     for res in results:
         html = html + """ 

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/StartupTimeHandler.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/StartupTimeHandler.py
@@ -159,6 +159,8 @@ def show_full_startup_time_report(title, results):
 def show_avg_max_min_in_html(title, list):
     html = """ 
         <h3 style="margin:0px">{}</h3>
+        <h4 style="margin:0px;color:blue">Startup Time Threshold: {}ms / Retrieve Times: {}
+        </h4>
         <table style="border: 1px solid black;white-space: initial;"> 
             <tr style="border: 1px solid black;">
                 <th style="border: 1px solid black;">
@@ -171,7 +173,7 @@ def show_avg_max_min_in_html(title, list):
                     Average startup time
                 </th>
             </tr>
-        """.format(title)
+        """.format(title, SettingsInfo().profile_constant.STARTUP_TIME_THRESHOLD, SettingsInfo().profile_constant.STARTUP_TIME_LOOP_TIME)
 
     html = html + """ 
         <tr style="border: 1px solid black;">

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
@@ -22,7 +22,8 @@ StartupTime001 - Get service startup time with creating containers
     startup time is less than threshold setting  ${total_startup_time_list}
     show full startup time report  Full startup time with creating containers  ${services_startup_time_list}
     show startup time with creating container avg max min  ${startup_time_with_create_container_aggregation_list}
-    set global variable  ${startup_time_with_create_container_aggregation_list}
+    set global variable  ${startup_time_with_create_container}  ${startup_time_with_create_container_aggregation_list}
+    [Teardown]  run keyword if test failed  set global variable  ${startup_time_with_create_container}  None
 
 StartupTime002 - Get service startup time without creating containers
     [Setup]  Run keywords   Deploy EdgeX  -  PerformanceMetrics
@@ -32,9 +33,9 @@ StartupTime002 - Get service startup time without creating containers
     startup time is less than threshold setting  ${total_startup_time_list}
     show full startup time report  Full startup time without creating containers  ${services_startup_time_list}
     show startup time without creating container avg max min   ${startup_time_without_create_container_aggregation_list}
-    set global variable  ${startup_time_without_create_container_aggregation_list}
-    [Teardown]  Shutdown services
-
+    set global variable  ${startup_time_without_create_container}  ${startup_time_without_create_container_aggregation_list}
+    [Teardown]  Run Keywords  Shutdown services
+                ...           AND  run keyword if test failed  set global variable  ${startup_time_without_create_container}  None
 
 
 *** Keywords ***

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/3_resource_usage_with_autoevent/resource_usage_with_autoevent.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/3_resource_usage_with_autoevent/resource_usage_with_autoevent.robot
@@ -12,7 +12,7 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/performance-metric-collecti
 *** Test Cases ***
 Resource001 - Get CPU and Memory Usage while sending autoevent
     Deploy EdgeX  -  PerformanceMetrics
-    ${CPU_MEM_USAGE_LIST}=  Retrieve CPU and memory usage and loop "${GET_CPU_MEM_LOOP_TIME}" times per "${GET_CPU_MEM_PERIOD}"s
+    ${CPU_MEM_USAGE_LIST}=  Retrieve CPU and memory usage and loop "${GET_CPU_MEM_LOOP_TIME}" times per "${ GET_CPU_MEM_INTERVAL}"s
     ${cpu_usage}=  retrieve cpu aggregation value  ${CPU_MEM_USAGE_LIST}
     ${mem_usage}=  retrieve mem aggregation value  ${CPU_MEM_USAGE_LIST}
     Show the summary table  ${CPU_MEM_USAGE_LIST}
@@ -21,11 +21,11 @@ Resource001 - Get CPU and Memory Usage while sending autoevent
     [Teardown]  Shutdown services
 
 *** Keywords ***
-Retrieve CPU and memory usage and loop "${GET_CPU_MEM_LOOP_TIME}" times per "${GET_CPU_MEM_PERIOD}"s
+Retrieve CPU and memory usage and loop "${GET_CPU_MEM_LOOP_TIME}" times per "${ GET_CPU_MEM_INTERVAL}"s
     @{CPU_MEM_USAGE_LIST}=  Create List
     sleep  30
     FOR  ${index}  IN RANGE  0  ${GET_CPU_MEM_LOOP_TIME}
-        sleep  ${GET_CPU_MEM_PERIOD}
+        sleep  ${ GET_CPU_MEM_INTERVAL}
         ${resource_usage}=  Retrieve CPU and memory usage
         CPU usage is over than threshold setting
         Memory usage is over than threshold setting

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/9_summary_reports/summary_reports.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/9_summary_reports/summary_reports.robot
@@ -4,5 +4,4 @@ Library         TAF/testCaseModules/keywords/performance-metrics-collection/Perf
 
 *** Test Cases ***
 Show performance summary reports
-    Show reports  ${startup_time_with_create_container_aggregation_list}
-    ...           ${startup_time_without_create_container_aggregation_list}
+    Show reports  ${startup_time_with_create_container}  ${startup_time_without_create_container}

--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -7,10 +7,15 @@ BACKWARD=${1:-}
 TEST_STRATEGY=${2:-}
 
 if [ "$TEST_STRATEGY" = "PerformanceMetrics" ]; then
+  # temporary fix
+  docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
+          --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable \
+          ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d consul
+
   docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable \
           ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d
-
+  sleep 5
 else
 
   # Deploy security service when security enabled


### PR DESCRIPTION
1. Add config variable to report.
2. Start consul first before starting all edgex services.
3. Fix report fails, if the running test of startup time fails.

Signed-off-by: Cherry Wang <cherry@iotechsys.com>