### PR TITLE
Fix report didn't generate when data fails to compare with threshold

### DIFF
--- a/TAF/testCaseModules/keywords/performance-metrics-collection/EventExportedTime.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/EventExportedTime.py
@@ -31,6 +31,8 @@ class EventExportedTime(object):
                     event["exported"] = event["pushed"] - event["origin"]
                     events.append(event)
                 else:
+                    logger.warn("Event didn't export.")
+                    logger.info("Event data: {}".format(event))
                     event["pushed"] = ""
                     event["exported"] = ""
 
@@ -80,9 +82,12 @@ def compare_export_time_with_threshold():
     for device in result["devices"]:
         for event in result["devices"][device]:
             compare_value = int(SettingsInfo().profile_constant.EXPORT_TIME_THRESHOLD)
-            if compare_value < event["exported"]:
-                raise Exception("{} event exported time is longer than {} ms".format(device,
-                                SettingsInfo().profile_constant.EXPORT_TIME_THRESHOLD))
+            if event["exported"] == "":
+                continue
+            else:
+                if compare_value < event["exported"]:
+                    raise Exception("{} event exported time is longer than {} ms".format(device,
+                                    SettingsInfo().profile_constant.EXPORT_TIME_THRESHOLD))
     return True
 
 

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/PerformanceSummaryReports.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/PerformanceSummaryReports.py
@@ -3,6 +3,7 @@ import RetrieveResourceUsage
 import StartupTimeHandler
 import PingResponse
 import EventExportedTime
+import RetrieveSystemInfo
 from robot.api import logger
 import os
 
@@ -11,6 +12,13 @@ class PerformanceSummaryReports(object):
 
     def show_reports(self, startup_with_creating_container, startup_without_creating_container):
         html = """<h2 style="margin:0px">Performance metrics summary report</h2><br>"""
+
+        # Retrieve system info
+        if hasattr(RetrieveSystemInfo, 'report_info'):
+            html = html + RetrieveSystemInfo.generate_report(RetrieveSystemInfo.report_info)
+        else:
+            logger.error("Retrieve System Info")
+
         # Suite: 1_retrieve_footprint
         if hasattr(RetrieveFootprint, 'resource_usage'):
             html = html + RetrieveFootprint.show_the_summary_table_in_html(RetrieveFootprint.resource_usage)

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveSystemInfo.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveSystemInfo.py
@@ -1,0 +1,83 @@
+import psutil
+import math
+import datetime
+from robot.api import logger
+
+
+class ReportInfo:
+    def __init__(self, logical_cpus, physical_cpus, cpu_freq, memory):
+        self.logical_cpus = logical_cpus
+        self.physical_cpus = physical_cpus
+        self.cpu_freq = cpu_freq
+        self.memory = memory
+
+
+class RetrieveSystemInfo(object):
+    def fetch_system_info(self):
+        global report_info
+        report_info = fetch_report_info()
+
+    def generate_system_report(self):
+        generate_report(report_info)
+
+
+# fetch_report_info fetches the system information via psutil (https://pypi.org/project/psutil/)
+def fetch_report_info():
+
+    logger.info(psutil.cpu_count(), also_console=True)
+    logger.info(psutil.cpu_freq(), also_console=True)
+    logger.info(psutil.virtual_memory(), also_console=True)
+
+    cpu_freq = 0
+    # The cpu_freq is None in some Virtual machine
+    if psutil.cpu_freq() is not None:
+        cpu_freq = psutil.cpu_freq().max
+    report_info = ReportInfo(
+        logical_cpus=psutil.cpu_count(),
+        physical_cpus=psutil.cpu_count(logical=False),
+        cpu_freq=cpu_freq,
+        memory=round(psutil.virtual_memory().total / math.pow(2, 30), 1)
+    )
+
+    return report_info
+
+
+def generate_report(report_info):
+    html = ""
+    # Html css style
+    html += """
+        <style>
+        .message * {
+            white-space: initial;
+        }
+        .custom-report table {
+          font-family: arial, sans-serif;
+          border-collapse: collapse;
+        }
+
+        .custom-report td, .custom-report th {
+          border: 1px solid #dddddd;
+          text-align: left;
+          padding: 8px;
+        }
+
+        .report-info > div{
+            padding: 10px 0 10px 0;
+        } 
+        </style>
+    """
+
+    # Report info
+    html += """
+        <div class='report-info'>
+            <div>Logical CPUs: {} core</div><div>Physical CPUs: {} core</div>
+            <div>CPU Frequency: {} MHz</div><div>Memory: {} GB</div>
+            <div>Report generated at {}</div>
+        </div>
+
+    """.format(report_info.logical_cpus, report_info.physical_cpus,
+               report_info.cpu_freq, report_info.memory,
+               datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S (UTC)"))
+
+    logger.info(html, html=True)
+    return html

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/0_retrieve_system_info/retrieve_system_info.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/0_retrieve_system_info/retrieve_system_info.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Library  TAF/testCaseModules/keywords/performance-metrics-collection/RetrieveSystemInfo.py
+
+
+*** Test Cases ***
+Get System Info
+    fetch system info
+    generate system report

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/1_retrieve_footprint/retrieve_footprint.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/1_retrieve_footprint/retrieve_footprint.robot
@@ -16,6 +16,6 @@ Footprint001 - Verify Image and Binary Footprint
     Given Deploy EdgeX  -  PerformanceMetrics
     When Fetch image binary footprint
     Then Show the summary table
-    And Image footprint is less than threshold value
-    And Binary footprint is less than threshold value
+    And Run keyword and continue on failure  Image footprint is less than threshold value
+    And Run keyword and continue on failure  Binary footprint is less than threshold value
     [Teardown]  Shutdown services

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
@@ -22,7 +22,6 @@ StartupTime001 - Get service startup time with creating containers
     show full startup time report  Full startup time with creating containers  ${services_startup_time_list}
     show startup time with avg max min  Startup time aggregations with creating containers  ${service_aggregations}
     set global variable  ${startup_time_with_create_container}  ${service_aggregations}
-    [Teardown]  run keyword if test failed  set global variable  ${startup_time_with_create_container}  None
 
 StartupTime002 - Get service startup time without creating containers
     [Setup]  Run keywords   Deploy EdgeX  -  PerformanceMetrics
@@ -32,8 +31,7 @@ StartupTime002 - Get service startup time without creating containers
     show full startup time report  Full startup time without creating containers  ${services_startup_time_list}
     show startup time with avg max min  Startup time aggregations without creating containers  ${service_aggregations}
     set global variable  ${startup_time_without_create_container}  ${service_aggregations}
-    [Teardown]  Run Keywords  Shutdown services
-                ...           AND  run keyword if test failed  set global variable  ${startup_time_without_create_container}  None
+    [Teardown]  Shutdown services
 
 
 *** Keywords ***
@@ -45,7 +43,7 @@ Deploy edgex with creating containers and get startup time
                     ...          stdout=${WORK_DIR}/TAF/testArtifacts/logs/clear_mem.log
         Start time is recorded
         Deploy EdgeX  -  PerformanceMetrics
-        ${services_startup_time}=  fetch services startup time
+        ${services_startup_time}=  Run keyword and continue on failure  fetch services startup time
         Shutdown services
         Append to list  ${service_startup_time_list}  ${services_startup_time}
         Check service is stopped or not
@@ -60,7 +58,7 @@ Deploy edgex without creating containers and get startup time
                     ...          stdout=${WORK_DIR}/TAF/testArtifacts/logs/clear_mem_cache.log
         Start time is recorded
         Deploy EdgeX  -  PerformanceMetrics
-        ${services_startup_time}=  fetch services startup time without creating containers
+        ${services_startup_time}=  Run keyword and continue on failure  fetch services startup time without creating containers
         Stop services
         Append to list  ${service_startup_time_list}  ${services_startup_time}
         Check service is stopped or not
@@ -75,8 +73,8 @@ Get startup time and add to dictionary
     FOR  ${service}  IN  @{service_keys}
         ${service_binary_list}=    Get service startup time list  ${services_startup_time}  ${service}  binaryStartupTime
         ${service_container_list}=    Get service startup time list  ${services_startup_time}  ${service}  startupTime
-        startup time is less than threshold setting  ${service_binary_list}
-        startup time is less than threshold setting  ${service_container_list}
+        Run keyword and continue on failure  startup time is less than threshold setting  ${service_binary_list}
+        Run keyword and continue on failure  startup time is less than threshold setting  ${service_container_list}
         ${binary_aggregations}=  Get avg max min values  ${service_binary_list}
         ${container_aggregations}=  Get avg max min values  ${service_container_list}
         ${aggregation_value}=  create dictionary  binaryStartupTime=${binary_aggregations}  startupTime=${container_aggregations}

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/3_resource_usage_with_autoevent/resource_usage_with_autoevent.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/3_resource_usage_with_autoevent/resource_usage_with_autoevent.robot
@@ -27,8 +27,8 @@ Retrieve CPU and memory usage and loop "${GET_CPU_MEM_LOOP_TIMES}" times per "${
     FOR  ${index}  IN RANGE  0  ${GET_CPU_MEM_LOOP_TIMES}
         sleep  ${ GET_CPU_MEM_INTERVAL}
         ${resource_usage}=  Retrieve CPU and memory usage
-        CPU usage is over than threshold setting
-        Memory usage is over than threshold setting
+        Run keyword and continue on failure  CPU usage is over than threshold setting
+        Run keyword and continue on failure  Memory usage is over than threshold setting
         Append to list  ${CPU_MEM_USAGE_LIST}  ${resource_usage}
     END
     [Return]   ${CPU_MEM_USAGE_LIST}

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/4_ping_response_time/ping_response_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/4_ping_response_time/ping_response_time.robot
@@ -62,7 +62,7 @@ Ping API for service
     @{RES_LIST}=  Create List
     FOR  ${index}  IN RANGE  0  ${PING_RES_LOOP_TIMES}
         ${res}  Ping api request  ${service_port}
-        Response time is less than threshold setting  ${service_name}  ${res}
+        Run keyword and continue on failure  Response time is less than threshold setting  ${service_name}  ${res}
         APPEND TO LIST  ${RES_LIST}     ${res}
     END
     [Return]  ${RES_LIST}

--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/5_event_exported_time/event_exported_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/5_event_exported_time/event_exported_time.robot
@@ -15,7 +15,7 @@ Measure the event exported time
     Given Deploy EdgeX  -  PerformanceMetrics  -mqtt
     When query events
     And fetch the exported time
-    Then exported time is less than threshold value
+    Then Run keyword and continue on failure  exported time is less than threshold value
     And show the summary table
     And show the aggregation table
     [Teardown]  Shutdown services  -  PerformanceMetrics  -mqtt

--- a/TAF/utils/scripts/docker/exec_performance_metrics.sh
+++ b/TAF/utils/scripts/docker/exec_performance_metrics.sh
@@ -4,7 +4,13 @@ USE_ARCH=${1:-x86_64}
 USE_SECURITY=${2:--}
 
 # Pull edgex images
-sh pull-images.sh ${USE_ARCH} ${USE_SECURITY}
+sh get-compose-file-perfermance.sh ${USE_ARCH} ${USE_SECURITY}
+
+# Pull images
+docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
+        --env WORK_DIR=${WORK_DIR} --security-opt label:disable \
+        ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" pull
+sleep 5
 
 # Run scripts to collect performance metrics and generate reports
 docker run --rm --network host --privileged -v ${WORK_DIR}:${WORK_DIR}:z -w ${WORK_DIR} -e ARCH=${USE_ARCH} \

--- a/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
@@ -17,8 +17,3 @@ cp docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml docker-compose.yaml
 # Insert required services for retrieving exported time
 sed -e '1,/- edgex-network/d' docker-compose-end-to-end.yaml > docker-compose-end-mqtt.yaml
 sed -e '/app-service-rules:/r docker-compose-end-mqtt.yaml' -e //N docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml > docker-compose-mqtt.yaml
-
-docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
-        --env WORK_DIR=${WORK_DIR} --security-opt label:disable \
-        ${COMPOSE_IMAGE} -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" pull
-sleep 5


### PR DESCRIPTION
- Fix report didn't generate when data fails to compare with the threshold.
- Add error log if events didn't export.

Fix #179 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>