### PR TITLE
Update app-service secrets V2 API testcases

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
@@ -12,29 +12,26 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-secrets.log
 ${api_version}  v2
 
 *** Test Cases ***
-SecretsPOST001 - Stores secrets to the secret client
-    When Store Secret Data With Empty Path
-    Then Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'
-         ...  Run keywords  Should Return Status Code "201"
-         ...  AND  Secrets Should be Stored
-         ...  ELSE  Should Return Status Code "500"
-
-SecretsPOST002 - Stores secrets to the secret client with Path
+SecretsPOST001 - Stores secrets to the secret client with Path
     When Store Secret Data With Path
     Then Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'
          ...  Run keywords  Should Return Status Code "201"
          ...  AND  Secrets Should be Stored
          ...  ELSE  Should Return Status Code "500"
 
-ErrSecretsPOST001 - Stores secrets to the secret client fails (missing key)
+ErrSecretsPOST001 - Stores secrets to the secret client fails (empty path)
+    When Store Secret Data With Empty Path
+    Then Should Return Status Code "400"
+
+ErrSecretsPOST002 - Stores secrets to the secret client fails (missing key)
     When Store Secret Data With Missing Key
     Then Should Return Status Code "400"
 
-ErrSecretsPOST002 - Stores secrets to the secret client fails (missing value)
+ErrSecretsPOST003 - Stores secrets to the secret client fails (missing value)
     When Store Secret Data With Missing Value
     Then Should Return Status Code "400"
 
-ErrSecretsPOST003 - Stores secrets to the secret client fails (security not enabled)
+ErrSecretsPOST004 - Stores secrets to the secret client fails (security not enabled)
     When Store Secret Data With Path
     Then Run Keyword if  $SECURITY_SERVICE_NEEDED == 'false'
          ...   Should Return Status Code "500"


### PR DESCRIPTION
update for https://github.com/edgexfoundry/edgex-taf/issues/155 based on the change https://github.com/edgexfoundry/app-functions-sdk-go/pull/497:
POST secrets without path returns status code 400

Signed-off-by: Ginny Guan <ginny@iotechsys.com>