### PR TITLE
Add core-metadata test cases

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/DELETE.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/DELETE.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device DELETE Test Cases
+
+*** Test Cases ***
+DeviceDELETE001 - Delete device by ID
+    Given Create A Device
+    When Delete Device By ID
+    Then Should Return Status Code "200"
+    And Device Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms
+
+DeviceDELETE002 - Delete device by name
+    Given Create A Device
+    When Delete Device By Name
+    Then Should Return Status Code "200"
+    And Device Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceDELETE001 - Delete device by ID with invalid id format
+    # use non uuid format, like d138fccc-f39a4fd0-bd32
+    Given Create A Device
+    When Delete Device By ID
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceDELETE002 - Delete device by ID with non-existent ID
+    When Delete Device By ID
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceDELETE003 - Delete device by name with empty value
+    When Delete Device By Name
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceDELETE004 - Delete device by name with non-existent name
+    When Delete Device By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Negative.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device GET Negative Test Cases
+
+*** Test Cases ***
+ErrDeviceGET001 - Query device by non-existent device name
+    When Query Device By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceGET002 - Check device exists by non-existent device name
+    When Check Device Exists By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDeviceGET003 - Query devices with empty device profile name
+    Given Create Device Profile
+    When Query All Devices With Specified Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profile
+
+ErrDeviceGET004 - Query all devices with empty device service name
+    Given Create Device Service
+    When Query All Devices With Specified Device Service
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services
+
+ErrDeviceGET005 - Query all devices with non-int value on offset/limit
+    Given Create Devices
+    When Query All Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device GET Positive Test Cases
+
+*** Test Cases ***
+DeviceGET007 - Query all devices with specified device profile by profile name
+    Given Create Multiple Devices With Several Profiles
+    When Query All Devices With Specified Profile
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Profile
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET008 - Query all devices with specified device profile by profile name and offset
+    Given Create Multiple Devices With Several Profiles
+    When Query All Devices With Specified Profile
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Profile
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET009 - Query all devices with specified device profile by profile name and limit
+    Given Create Multiple Devices With Several Profiles
+    When Query All Devices With Specified Profile
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Profile
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET010 - Query all devices with specified device service by service name
+    Given Create Multiple Devices With Several Device Services
+    When Query All Devices With Specified Device Service
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Device Service
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET011 - Query all devices with specified device service by service name and offset
+    Given Create Multiple Devices With Several Device Services
+    When Query All Devices With Specified Device Service
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Device Service
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET012 - Query all devices with specified device service by service name and limit
+    Given Create Multiple Devices With Several Device Services
+    When Query All Devices With Specified Device Service
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Devices Should Be Linked To Specified Device Service
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot
@@ -1,0 +1,63 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device GET Positive Test Cases
+
+*** Test Cases ***
+DeviceGET001 - Query all devices
+    Given Create Multiple Devices
+    When Query All Devices
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET002 - Query all devices with offset
+    Given Create Multiple Devices
+    When Query All Devices
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET003 - Query all devices with limit
+    Given Create Multiple Devices
+    When Query All Devices
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET004 - Query all devices with specified labels
+    Given Create Multiple Devices
+    When Query All Devices
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Devices Should Be Linked To Specified Label
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET005 - Query device by name
+    Given Create A Device
+    When Query Device By Name
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices
+
+DeviceGET006 - Check device exists by name
+    Given Create A Device
+    When Check Device Exists By Name
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Devices

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
@@ -1,0 +1,72 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device PATCH Testcases
+
+
+*** Test Cases ***
+ErrDevicePATCH001 - Update device with use duplicate device name
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "409"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH002 - Update device with device name validate error
+    # Empty device name
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH003 - Update device with adminState validate error
+    # Empty adminState
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH004 - Update device with operatingState validate error
+    # Empty operatingState
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH005 - Update device with serviceName validate error
+    # Empty serviceName
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH006 - Update device with profileName validate error
+    # Empty profileName
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH007 - Update device with protocols validate error
+    # Empty protocols
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH008 - Update device with adminState value validate error
+    # Out of optional value for adminState
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCH009 - Update device with operatingState value validate error
+    # Out of optional value for operatingState
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device PATCH Testcases
+
+
+*** Test Cases ***
+DevicePATCH001 - Update device
+    # name, operatingState, adminState, labels, protocols
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Response Time Should Be Less Than "1200"ms
+
+DevicePATCH002 - Update device with device service and profile
+    # profileName, serviceName
+    Given Create Multiple Devices
+    When Update Multiple Devices
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device POST Test Cases
+
+
+*** Test Cases ***
+ErrDevicePOST001 - Create device with duplicate device name
+    # 2 devices with same device name
+    When Create multiple device
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index 0 Should Contain Status Code "201" And id
+    And Item Index 1 Should Contain Status Code "409"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST002 - Create device with device name validate error
+    # Empty device name
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST003 - Create device with adminState validate error
+    # Empty adminState
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST004 - Create device with operatingState validate error
+    # Empty operatingState
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST005 - Create device with serviceName validate error
+    # Empty serviceName
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST006 - Create device with profileName validate error
+    # Empty profileName
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST007 - Create device with protocols validate error
+    # Empty protocols
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST008 - Create device with adminState value validate error
+    # Out of optional value for adminState
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePOST009 - Create device with operatingState value validate error
+    # Out of optional value for operatingState
+    When Create multiple device
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Positive.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device POST Test Cases
+
+
+*** Test Cases ***
+DevicePOST001 - Create device with same device service
+    When Create Multiple Device
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "201" And id
+    And Response Time Should Be Less Than "1200"ms
+
+DevicePOST002 - Create device with different device service
+    When Create Multiple Device
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "201" And id
+    And Response Time Should Be Less Than "1200"ms
+
+DevicePOST003 - Create device with uuid
+    # Request body contains uuid
+    When Create Multiple Device
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "201" And id
+    And Returned UUID Should Be The Same As Assigned
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Negative.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Profile DELETE Negative Test Cases
+
+*** Test Cases ***
+ErrProfileDELETE001 - Delete device profile by invalid format ID
+    # ID is existed, but format is invalid
+    Given Create A Device Profile
+    When Delete Device Profile By ID
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileDELETE002 - Delete device profile by non-existent ID
+    When Delete Device Profile By ID
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileDELETE003 - Delete device profile by ID that used by device
+    Given Create A Device Profile
+    And Create A Device
+    When Delete Device Profile By ID
+    Then Should Return Status Code "423"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileDELETE004 - Delete device profile by empty name
+    When Delete Device Profile By Name
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileDELETE005 - Delete device profile by non-existent name
+    When Delete Device Profile By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileDELETE006 - Delete device profile by name that used by device
+    Given Create A Device Profile
+    And Create A Device
+    When Delete Device Profile By Name
+    Then Should Return Status Code "423"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Positive.robot
@@ -1,0 +1,21 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Profile DELETE Positive Test Cases
+
+*** Test Cases ***
+ProfileDELETE001 - Delete device profile by ID
+    Given Create A Device Profile
+    When Delete Device Profile By ID
+    Then Should Return Status Code "200"
+    And Device Profile Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms
+
+ProfileDELETE002 - Delete device profile by name
+    Given Create A Device Profile
+    When Delete Device Profile By Name
+    Then Should Return Status Code "200"
+    And Device Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Negative.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Profile GET Negative Test Cases
+
+*** Test Cases ***
+ErrProfileGET001 - Query device profile by empty name
+    When Query Device Profile By Name
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileGET002 - Query device profile by non-existent name
+    When Query Device Profile By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileGET003 - Query device profiles by empty manufacturer value
+    When Query Device Profile By Manufacturer
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileGET004 - Query device profiles by existed manufacturer and empty model value
+    When Query Device Profile By Manufacturer And Model
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileGET005 - Query device profiles by empty model value
+    When Query Device Profile By Model
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfileGET006 - Query all device profile with non-int value on offset/limit
+    When Query All Device Profiles
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive-II.robot
@@ -1,0 +1,98 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Profile GET Positive Test Cases
+
+*** Test Cases ***
+ProfileGET009 - Query device profiles by manufacturer's model
+    # Multiple device profile which part of same manufacturer and same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer And Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer And Model
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET010 - Query device profiles by manufacturer's model and offset
+    # Multiple device profile which part of same manufacturer and same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer And Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer And Model
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET011 - Query device profiles by manufacturer's model and limit
+    # Multiple device profile which part of same manufacturer and same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer And Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer And Model
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET012 - Query device profiles by model
+    # Multiple device profile with different manufacturer but same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Model
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET013 - Query device profiles by model and offset
+    # Multiple device profile with different manufacturer but same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Model
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET014 - Query device profiles by model and limit
+    # Multiple device profile with different manufacturer but same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Model
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET015 - Query device profiles by empty manufacturer value
+    # Multiple device profile which part of same manufacturer and same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Response Body Should Be An Empty Array
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET016 - Query device profiles by empty model value
+    # Multiple device profile which part of same manufacturer and same model
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Model
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Response Body Should Be An Empty Array
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot
@@ -1,0 +1,90 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Profile GET Positive Test Cases
+
+*** Test Cases ***
+ProfileGET001 - Query all device profiles
+    Given Create Multiple Device Profiles
+    When Query All Device Profiles
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET002 - Query all device profiles by offset
+    Given Create Multiple Device Profiles
+    When Query All Device Profiles
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET003 - Query all device profiles by limit
+    Given Create Multiple Device Profiles
+    When Query All Device Profiles
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET004 - Query all device profiles by labels
+    Given Create Multiple Device Profiles
+    When Query All Device Profiles
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Profiles Should Be Linked To Specified Label
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET005 - Query device profile by name
+    Given Create A Device Profile
+    When Query Device Profile By Name
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET006 - Query device profiles by manufacturer
+    # Multiple device profile which part of same manufacturer
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET007 - Query device profiles by manufacturer and offset
+    # Multiple device profile which part of same manufacturer
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles
+
+ProfileGET008 - Query device profiles by manufacturer and limit
+    # Multiple device profile which part of same manufacturer
+    Given Create Multiple Device Profiles
+    When Query Device Profile By Manufacturer
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Should Be Linked To Specified Manufacturer
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Profiles

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
@@ -1,0 +1,61 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}          Core Metadata Device Profile PUT Negative Test Cases
+
+*** Test Cases ***
+ErrProfilePUTUpload001 - Update device profile by upload file and profile name is not existed
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload002 - Update device profile by upload file with profile name validation error
+    # Empty profile name
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload003 - Update device profile by upload file with deviceResources validation error
+    # Empty deviceResources
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload004 - Update device profile by upload file with PropertyValue validation error
+    # deviceResources > PropertyValue without type
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload005 - Update device profile by upload file with ProfileResource validation error
+    # deviceCommands > ProfileResource without name
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload006 - Update device profile by upload file with coreCommands name validation error
+    # Contains valid profile body
+    # coreCommands without name
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUTUpload007 - Update device profile by upload file with coreCommands command validation error
+    # Contains valid profile body
+    # Duplicated device profile name
+    # coreCommands get and put both are false
+    Given Create Multiple Device Profiles
+    When Update Device Profile By Upload File
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
@@ -1,0 +1,68 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}          Core Metadata Device Profile PUT Positive Test Cases
+
+*** Test Cases ***
+ErrProfilePUT001 - Update device profile with invalid profile name
+    # Duplicate profile name
+    # Non-existent profile name
+    Given Create Multiple Device Profile
+    When Update Device Profile
+    Then Should Return Status Code "207"
+    And Item Index 0 Should Contain Status Code "409"
+    And Item Index 1 Should Contain Status Code "404"
+    And Profile Data Should Not Be Updated
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Profiles
+
+ErrProfilePUT002 - Update device profile with profile name validation error
+    # Empty profile name
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUT003 - Update device profile with deviceResources validation error
+    # Empty deviceResources
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUT004 - Update device profile with PropertyValue validation error
+    # deviceResources > PropertyValue without type
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUT005 - Update device profile with ProfileResource validation error
+    # deviceCommands > ProfileResource without name
+    # Contains valid profile body
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUT006 - Update device profile with coreCommands name validation error
+    # Contains valid profile body
+    # coreCommands without name
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrProfilePUT007 - Update device profile with coreCommands command validation error
+    # Contains valid profile body
+    # Duplicated device profile name
+    # coreCommands get and put both are false
+    Given Create Multiple Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}          Core Metadata Device Profile PUT Positive Test Cases
+
+*** Test Cases ***
+ProfilePUT001 - Update a device profile
+    # Update profile name
+    Given Create A Device Profile
+    When Update Device Profile
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Profile Data Should Be Updated
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Profiles
+
+ProfilePUT002 - Update multiple device profiles
+    # Update different field for different profile
+    Given Create Multiple Device Profiles
+    When Update Multiple Device Profile
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Profile Data Should Be Updated
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Profiles
+
+ProfilePUT003 - Update device profiles by upload file
+    Given Create Device Profiles
+    When Update Device Profile
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Profile Data Should Be Updated
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Profiles

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Negative.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service DELETE Negative Test Cases
+
+*** Test Cases ***
+ErrServiceDELETE001 - Delete device service by ID with invalid id format
+    # use non uuid format, like d138fccc-f39a4fd0-bd32
+    Given Create A Device Service
+    When Delete Device Service By ID
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceDELETE002 - Delete device service by ID that used by device
+    Given Create A Device Service
+    And Create A Device
+    When Delete Device Service By ID
+    Then Should Return Status Code "423"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceDELETE003 - Delete device service by ID with non-existent id
+    When Delete Device Service By ID
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceDELETE004 - Delete device service by name with empty name
+    When Delete Device Service By Name
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceDELETE005 - Delete device service by name that used by device
+    Given Create A Device Service
+    And Create A Device
+    When Delete Device Service By Name
+    Then Should Return Status Code "423"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceDELETE006 - Delete device service by name with non-existent service name
+    When Delete Device Service By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Positive.robot
@@ -1,0 +1,21 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service DELETE Positive Test Cases
+
+*** Test Cases ***
+ServiceDELETE001 - Delete device service by ID
+    Given Create A Device Service
+    When Delete Device Service By ID
+    Then Should Return Status Code "200"
+    And Device Service Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms
+
+ServiceDELETE002 - Delete device service by name
+    Given Create A Device Service
+    When Delete Device Service By Name
+    Then Should Return Status Code "200"
+    And Device Should Be Deleted
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Negative.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service GET Negative Test Cases
+
+*** Test Cases ***
+ErrServiceGET001 - Query device service by empty name
+    When Query Device Service By Name
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceGET002 - Query device service by non-existent name
+    When Query Device Service By Name
+    Then Should Return Status Code "404"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrServiceGET003 - Query all device service with non-int value on offset/limit
+    Given Create Device Service
+    When Query All Device Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service GET Positive Test Cases
+
+*** Test Cases ***
+ServiceGET001 - Query all device services
+    Given Create Multiple Device Services
+    When Query All Device Services
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services
+
+ServiceGET001 - Query all device services by offset
+    Given Create Multiple Device Services
+    When Query All Device Services
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Skipped Records Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services
+
+ServiceGET001 - Query all device services by limit
+    Given Create Multiple Device Services
+    When Query All Device Services
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Returned Number Should Be The Same As Setting
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services
+
+ServiceGET001 - Query all device services by labels
+    Given Create Multiple Device Services
+    When Query All Device Services
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Device Services Should Be Linked To Specified Label
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services
+
+ServiceGET002 - Query device service by name
+    Given Create A Device Service
+    When Query Device Service By Name
+    Then Should Return Status Code "200"
+    And Should Have Content-Type "application/json"
+    And Validate Response Schema
+    And Response Time Should Be Less Than "1200"ms
+    [Teardown]  Delete Device Services

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Negative.robot
@@ -1,0 +1,58 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service PATCH Negative Test Cases
+
+
+*** Test Cases ***
+ErrDevicePATCH001 - Update device with use duplicate device service name
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "409"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate001 - Update device with service name validate error
+    # Empty service name
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate002 - Update device with baseAddress validate error
+    # Empty baseAddress
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate003 - Update device with adminState validate error
+    # Empty adminState
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate004 - Update device with adminState value validate error
+    # Out of optional value for adminState
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate005 - Update device with operatingState validate error
+    # Empty operatingState
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms
+
+ErrDevicePATCHValidate006 - Update device with operatingState validate error
+    # Out of optional value for operatingState
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "400"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Positive.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Device Service PATCH Positive Test Cases
+
+
+*** Test Cases ***
+DevicePATCH001 - Update device services
+    # name, operatingState, adminState, labels, protocols
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Response Time Should Be Less Than "1200"ms
+
+DevicePATCH002 - Update device with device service and profile
+    # device service and profile
+    Given Create Multiple Device Services
+    When Update Multiple Devices Services
+    Then Should Return Status Code "207"
+    And Should Have Content-Type "application/json"
+    And Item Index All Should Contain Status Code "200"
+    And Response Time Should Be Less Than "1200"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/info/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/info/GET.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Resource         TAF/testCaseModules/keywords/commonKeywords.robot
+Suite Setup      Setup Suite
+
+*** Variables ***
+${SUITE}         Core Metadata Info GET Test Cases
+
+*** Test Cases ***
+InfoGET001 - Query ping
+    When Query Ping
+    Then Should Return Status Code "200" And Timestamp
+    And Response Time Should Be Less Than "1200"ms
+
+InfoGET002 - Query version
+    When Query Version
+    Then Should Return Status Code "200" And Version
+    And Response Time Should Be Less Than "1200"ms
+
+InfoGET003 - Query metrics
+    When Query Metrics
+    Then Should Return Status Code "200" And Metrics
+    And Response Time Should Be Less Than "1200"ms
+
+InfoGET004 - Query config
+    When Query Config
+    Then Should Return Status Code "200" And Config
+    And Response Time Should Be Less Than "1200"ms


### PR DESCRIPTION
Contain the following test cases.
- Device
- Device Profile without POST Method.
- Device Service without POST Method.

POST method for Device Profile and Device Service is in #189.
Fix #106 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>