### PR TITLE
Add new variable SHA1 for smoke testing

### DIFF
--- a/TAF/utils/scripts/docker/docker-compose-device-service.yaml
+++ b/TAF/utils/scripts/docker/docker-compose-device-service.yaml
@@ -1,7 +1,7 @@
   device-virtual:
     image: ${virtual}
     ports:
-    - "49990:49990"
+    - 127.0.0.1:49990:49990/tcp
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
@@ -23,7 +23,7 @@
   edgex-device-modbus:
     image: ${modbus}
     ports:
-      - "49991:49991"
+      - 127.0.0.1:49991:49991/tcp
     container_name: edgex-device-modbus
     hostname: edgex-device-modbus
     networks:
@@ -48,7 +48,6 @@
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
     ports:
-      - "1502:1502"
+      - 127.0.0.1:1502:1502/tcp
     networks:
       - edgex-network
-

--- a/TAF/utils/scripts/docker/docker-compose-end-to-end.yaml
+++ b/TAF/utils/scripts/docker/docker-compose-end-to-end.yaml
@@ -1,7 +1,7 @@
   app-service-http-export:
     image: ${appService}
     ports:
-      - "48096:48096"
+      - 127.0.0.1:48096:48096/tcp
     container_name: app-service-http-export
     hostname: app-service-http-export
     environment:
@@ -20,11 +20,14 @@
       Writable_LogLevel: DEBUG
     networks:
       - edgex-network
+    depends_on:
+      - consul
+      - data
 
   app-service-mqtt-export:
     image: ${appService}
     ports:
-      - "48097:48097"
+      - 127.0.0.1:48097:48097/tcp
     container_name: app-service-mqtt-export
     hostname: app-service-mqtt-export
     environment:
@@ -43,6 +46,9 @@
       Writable_LogLevel: DEBUG
     networks:
       - edgex-network
+    depends_on:
+      - consul
+      - data
 
   mqtt-broker:
     image: eclipse-mosquitto
@@ -56,7 +62,7 @@
   app-service-blackbox-tests:
     image: ${appService}
     ports:
-      - "48095:48095"
+      - 127.0.0.1:48095:48095/tcp
     container_name: app-service-blackbox-tests
     hostname: app-service-blackbox-tests
     environment:
@@ -69,11 +75,14 @@
       EDGEX_SECURITY_SECRET_STORE: "false"
     networks:
       - edgex-network
+    depends_on:
+      - consul
+      - data
 
   app-service-http-export-secrets:
     image: ${appService}
     ports:
-      - "48098:48098"
+      - 127.0.0.1:48098:48098/tcp
     container_name: app-service-http-export-secrets
     hostname: app-service-http-export-secrets
     environment:
@@ -105,4 +114,6 @@
     - /tmp/edgex/secrets/appservice-http-export-secrets:/tmp/edgex/secrets/appservice-http-export-secrets:ro,z
     networks:
       - edgex-network
-
+    depends_on:
+      - consul
+      - data

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -5,6 +5,7 @@ USE_DB=${1:--redis}
 USE_ARCH=${2:--x86_64}
 USE_SECURITY=${3:--}
 USE_RELEASE=${4:-nightly-build}
+USE_SHA1=${5:-master}
 
 # # x86_64 or arm64
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64"
@@ -17,7 +18,7 @@ mkdir temp
 if [ "$USE_RELEASE" = "nightly-build" ]; then
   # generate single file docker-compose.yml for target configuration without
   # default device services, i.e. no device-virtual service
-  ./sync-nightly-build.sh ${USE_ARM64} ${USE_NO_SECURITY}
+  ./sync-nightly-build.sh ${USE_SHA1} ${USE_NO_SECURITY} ${USE_ARM64}
 
   # Need to remove the existing device services so the added ones below don't conflict
   sed '/  device-rest:/,/- 127.0.0.1:49990:49990\/tcp/d' docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml > temp/docker-compose-temp.yaml

--- a/TAF/utils/scripts/docker/sync-nightly-build.sh
+++ b/TAF/utils/scripts/docker/sync-nightly-build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-
-NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files"
-
-# x86_64 or arm64
-USE_ARM64=$1
+# Use specified commit or master
+USE_SHA1=$1
 
 # security or no security
 USE_NO_SECURITY=$2
+
+# x86_64 or arm64
+USE_ARM64=$3
+
+NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/${USE_SHA1}/releases/nightly-build/compose-files"
 
 COMPOSE_FILE="docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml"
 curl -o ${COMPOSE_FILE} "${NIGHTLY_BUILD_URL}/${COMPOSE_FILE}"


### PR DESCRIPTION
1. Adding the SHA1 field for downloading compose files from developer-script.
2. Based on the developer-script compose file to update the port number.
3. Add depend_on on all app-service services.

Fix #191 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>