### PR TITLE
Implement data GET event by id and event count V2 tests

### DIFF
--- a/TAF/testData/core-data/readings_data.json
+++ b/TAF/testData/core-data/readings_data.json
@@ -18,7 +18,7 @@
     ],
     "origin": 0,
     "valueType": "Float32",
-    "floatEncoding": "IEEE-754",
+    "floatEncoding": "eNotation",
     "value": "39.5"
   },
   "Binary Reading": {

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
@@ -1,37 +1,57 @@
 *** Settings ***
-Resource         TAF/testCaseModules/keywords/commonKeywords.robot
-Suite Setup      Setup Suite
+Library      uuid
+Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
+Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+Suite Setup  Run Keywords  Setup Suite
+...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Default Tags    v2-api
 
 *** Variables ***
 ${SUITE}         Core-Data Event GET Negative Testcases
+${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/core-data-get-negative.log
+${api_version}    v2
 
 *** Test Cases ***
-ErrEventGET001 - Query event by ID fails
-    When Query Event By invalid ID
+ErrEventGET001 - Query event by ID fails (Non-existent ID)
+    ${random_uuid}=  Evaluate  str(uuid.uuid4())
+    When Query Event By Event Id "${random_uuid}"
     Then Should Return Status Code "404"
+    And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
-ErrEventGET002 - Query all events with specified device by device id fails
-    When Query All Events with Specified Device By Invalid Device ID
+ErrEventGET002 - Query event by ID fails (Not UUID)
+    When Query Event By Event Id "InvalidID"
+    Then Should Return Status Code "400"
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+
+ErrEventGET003 - Query all events with specified device by device name fails
+    [Tags]  Skipped
+    When Query All Events with Specified Device By Non-existent Device Name
     Then Should return Status Code "404"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
-ErrEventGET003 - Query events by start/end time fails (Invalid Start)
+ErrEventGET004 - Query events by start/end time fails (Invalid Start)
+    [Tags]  Skipped
     When Query Events By Invalid Start Time
     Then Should Return Status Code "400"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
-ErrEventGET004 - Query events by start/end time fails (Invalid End)
+ErrEventGET005 - Query events by start/end time fails (Invalid End)
+    [Tags]  Skipped
     When Query Events By Invalid End Time
     Then Should Return Status Code "400"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
-ErrEventGET005 - Query events by start/end time fails (Start>End)
+ErrEventGET006 - Query events by start/end time fails (Start>End)
+    [Tags]  Skipped
     When Query Events By Invalid Start/End Time
     Then Should Return Status Code "400"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
-ErrEventGET006 - Query a count of all of events with specified device by device id fails
-    When Query All Events Count With Specified Device By Invalid Device ID
+ErrEventGET007 - Query a count of all of events with specified device by device name fails
+    [Tags]  Skipped
+    When Query All Events Count With Specified Device By Non-existent Device Name
     Then Should Return Status Code "404"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
@@ -1,12 +1,19 @@
 *** Settings ***
-Resource         TAF/testCaseModules/keywords/commonKeywords.robot
-Suite Setup      Setup Suite
+Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
+Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+Suite Setup  Run Keywords  Setup Suite
+...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Default Tags    v2-api
 
 *** Variables ***
-${SUITE}         Core-Data Event GET Postive Testcases
+${SUITE}          Core-Data Event GET Postive Testcases
+${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/core-data-get-positive.log
+${api_version}    v2
 
 *** Test Cases ***
 EventGET001 - Query all events
+    [Tags]  Skipped
     Given Create Multiple Events
     When Query All Events
     Then Should Return Status Code "200"
@@ -16,15 +23,17 @@ EventGET001 - Query all events
     [Teardown]  Delete Events
 
 EventGET002 - Query event by ID
-    Given Create An Event
-    When Query Event By ID
-    Then Should Return Status Code "200"
-    And Should Have Content-Type "application/json"
-    And Validate Response Schema
+    Given Generate An Event Sample With Simple Readings
+    And Create Events
+    When Query Event By Event Id "${id}"
+    log to console  ${content}
+    Then Should Return Status Code "200" And event
+    And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete Events
+    #[Teardown]  Delete Events
 
-EventGET003 - Query all events with specified device by device id
+EventGET003 - Query all events with specified device by device name
+    [Tags]  Skipped
     Given Create Multiple Events With Several Devices
     When Query All Events With Specified Device
     Then Should Return Status Code "200"
@@ -34,6 +43,7 @@ EventGET003 - Query all events with specified device by device id
     [Teardown]  Delete Events
 
 EventGET004 - Query events by start/end time
+    [Tags]  Skipped
     Given Create Multiple Events
     When Query Events By Start/End Time
     Then Should Return Status Code "200"
@@ -42,15 +52,17 @@ EventGET004 - Query events by start/end time
     [Teardown]  Delete Events
 
 EventGET005 - Query a count of all of events
-    Given Create Multiple Events
+    Given Generate Multiple Events Sample With Simple Readings
+    And Create Events
     When Query All Events Count
     Then Should Return Status Code "200"
-    And Should Have Content-Type "application/json"
-    And Count Should Be Correct
+    And Should Return Content-Type "application/json"
+    #And Should Be Equal  ${content}[Count]  4
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete Events
+    #[Teardown]  Delete Events
 
-EventGET006 - Query a count of all of events with specified device by device id
+EventGET006 - Query a count of all of events with specified device by device name
+    [Tags]  Skipped
     Given Create Multiple Events with Several Devices
     When Query All Events Count With Specified Device
     Then Should Return Status Code "200"

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
@@ -27,6 +27,7 @@ ErrEventPOST002 - Create events fails (Bad Events)
          Given Generate Bad Event With ${property}
          And Create Events
          Then Should Return Status Code "400"
+         And Should Return Content-Type "application/json"
          And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     END
 
@@ -36,6 +37,7 @@ ErrEventPOST003 - Create events fails (Bad Simple Readings)
          Given Generate Bad Simple Reading With ${property}
          And Create Events
          Then Should Return Status Code "400"
+         And Should Return Content-Type "application/json"
          And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     END
 
@@ -45,6 +47,7 @@ ErrEventPOST004 - Create events fails (Bad Binary Readings)
          Given Generate Bad Binary Reading With ${property}
          And Create Events
          Then Should Return Status Code "400"
+         And Should Return Content-Type "application/json"
          And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     END
 


### PR DESCRIPTION
Fix https://github.com/edgexfoundry/edgex-taf/issues/199
1. change origin to nanosecond
2. change floatEncoding to eNotation in readings_data.json
3. add content-type check to post-negative
4. get event by id positive and negative testcases
5. get event count testcases

Signed-off-by: Ginny Guan <ginny@iotechsys.com>