### PR TITLE
Use master for USE_SHA1 argument when executing performance metrics collection

### DIFF
--- a/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
@@ -10,7 +10,7 @@ USE_SECURITY=${2:--}
 [ "$USE_SECURITY" != '-security-' ] && USE_NO_SECURITY="-no-secty"
 
 # # sync docker-compose file from developer-script repo
-./sync-nightly-build.sh ${USE_ARM64} ${USE_NO_SECURITY}
+./sync-nightly-build.sh master ${USE_ARM64} ${USE_NO_SECURITY}
 
 cp docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml docker-compose.yaml
 


### PR DESCRIPTION
Add argument value "master" on get-compose-file-performance.sh file.
Fix #202 

Signed-off-by: Cherry Wang <cherry@iotechsys.com>