### PR TITLE
Fix SmokeTest failures and use Force Tags

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
-Default Tags    v2-api
+Force Tags      v2-api
 
 *** Variables ***
 ${SUITE}          Core Metadata Device GET Positive Test Cases

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative-II.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
-Default Tags    v2-api
+Force Tags      v2-api
 
 *** Variables ***
 ${SUITE}          Core Metadata Device PATCH Testcases

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
-Default Tags    v2-api
+Force Tags      v2-api
 
 *** Variables ***
 ${SUITE}          Core Metadata Device PATCH Testcases

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
-Default Tags    v2-api
+Force Tags      v2-api
 
 *** Variables ***
 ${SUITE}          Core Metadata Device PATCH Testcases
@@ -39,7 +39,6 @@ DevicePATCH002 - Update device with device service and profile
 Deivce ${type} Should Be Updated
     ${list}=  Create List  Test-Device  Test-Device-Locked  Test-Device-Disabled  Test-Device-AutoEvents
     ${expected_keys}=  Create List  name  operatingState  adminState  protocols  serviceName  profileName
-    Run Keyword If  "${type}" == "Data"  Set Test Variable  ${index}  ${EMPTY}
     FOR  ${device}  IN  @{list}
         Query Device By Name  ${device}
         ${keys}=  Get Dictionary Keys  ${content}[device]


### PR DESCRIPTION
1. unset ${index} to empty
2. use Force Tages instead of Default Tags

Signed-off-by: Ginny Guan <ginny@iotechsys.com>