### PR TITLE
Revert "Change image url to use dockerhub hanoi release"

### DIFF
--- a/TAF/utils/scripts/docker/arm64.env
+++ b/TAF/utils/scripts/docker/arm64.env
@@ -1,7 +1,7 @@
 # Image Variables
-virtual=edgexfoundry/docker-device-virtual-go-arm64:1.3.0
-mqtt=edgexfoundry/docker-device-mqtt-go-arm64:1.3.0
-random=edgexfoundry/docker-device-random-go-arm64:1.3.0
-modbus=edgexfoundry/docker-device-modbus-go-arm64:1.3.0
+virtual=nexus3.edgexfoundry.org:10004/docker-device-virtual-go-arm64:master
+mqtt=nexus3.edgexfoundry.org:10004/docker-device-mqtt-go-arm64:master
+random=nexus3.edgexfoundry.org:10004/docker-device-random-go-arm64:master
+modbus=nexus3.edgexfoundry.org:10004/docker-device-modbus-go-arm64:master
 modbusSimulator=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator-arm64:latest
-appService=edgexfoundry/docker-app-service-configurable-arm64:1.3.0
+appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master

--- a/TAF/utils/scripts/docker/get-compose-file-backward.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-backward.sh
@@ -44,8 +44,8 @@ else
   sed -i 's/\${ARCH}//g' docker-compose-backward.yaml
 fi
 
-sed -i 's/\${CORE_EDGEX_REPOSITORY}/edgexfoundry/g' docker-compose-backward.yaml
-sed -i 's/\${CORE_EDGEX_VERSION}/1.3.0/g' docker-compose-backward.yaml
+sed -i 's/\${CORE_EDGEX_REPOSITORY}/nexus3.edgexfoundry.org:10004/g' docker-compose-backward.yaml
+sed -i 's/\${CORE_EDGEX_VERSION}/master/g' docker-compose-backward.yaml
 sed -i 's/\${DEV}//g' docker-compose-backward.yaml
 sed -i 's/\  redis:/  database:/g' docker-compose-backward.yaml
 sed -i 's/\- redis/- database/g' docker-compose-backward.yaml

--- a/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
@@ -12,8 +12,8 @@ USE_SECURITY=${2:--}
 # # sync docker-compose file from developer-script repo
 ./sync-nightly-build.sh master ${USE_NO_SECURITY} ${USE_ARM64}
 
-cp docker-compose-hanoi${USE_NO_SECURITY}${USE_ARM64}.yml docker-compose.yaml
+cp docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml docker-compose.yaml
 
 # Insert required services for retrieving exported time
 sed -e '1,/- edgex-network/d' docker-compose-end-to-end.yaml > docker-compose-end-mqtt.yaml
-sed -e '/app-service-rules:/r docker-compose-end-mqtt.yaml' -e //N docker-compose-hanoi${USE_NO_SECURITY}${USE_ARM64}.yml > docker-compose-mqtt.yaml
+sed -e '/app-service-rules:/r docker-compose-end-mqtt.yaml' -e //N docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml > docker-compose-mqtt.yaml

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -4,7 +4,7 @@
 USE_DB=${1:--redis}
 USE_ARCH=${2:--x86_64}
 USE_SECURITY=${3:--}
-USE_RELEASE=${4:-hanoi}
+USE_RELEASE=${4:-nightly-build}
 USE_SHA1=${5:-master}
 
 # # x86_64 or arm64
@@ -15,13 +15,13 @@ USE_SHA1=${5:-master}
 
 # # nightly or other release
 mkdir temp
-if [ "$USE_RELEASE" = "hanoi" ]; then
+if [ "$USE_RELEASE" = "nightly-build" ]; then
   # generate single file docker-compose.yml for target configuration without
   # default device services, i.e. no device-virtual service
   ./sync-nightly-build.sh ${USE_SHA1} ${USE_NO_SECURITY} ${USE_ARM64}
 
   # Need to remove the existing device services so the added ones below don't conflict
-  sed '/  device-rest:/,/- 127.0.0.1:49990:49990\/tcp/d' docker-compose-${USE_RELEASE}${USE_NO_SECURITY}${USE_ARM64}.yml > temp/docker-compose-temp.yaml
+  sed '/  device-rest:/,/- 127.0.0.1:49990:49990\/tcp/d' docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml > temp/docker-compose-temp.yaml
 
   # Insert device services into the compose file
   sed -e '/app-service-rules:/r docker-compose-device-service.yaml' -e //N temp/docker-compose-temp.yaml > temp/device-service-temp.yaml

--- a/TAF/utils/scripts/docker/sync-nightly-build.sh
+++ b/TAF/utils/scripts/docker/sync-nightly-build.sh
@@ -8,7 +8,7 @@ USE_NO_SECURITY=$2
 # x86_64 or arm64
 USE_ARM64=$3
 
-NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/${USE_SHA1}/releases/hanoi/compose-files"
+NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/${USE_SHA1}/releases/nightly-build/compose-files"
 
-COMPOSE_FILE="docker-compose-hanoi${USE_NO_SECURITY}${USE_ARM64}.yml"
+COMPOSE_FILE="docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml"
 curl -o ${COMPOSE_FILE} "${NIGHTLY_BUILD_URL}/${COMPOSE_FILE}"

--- a/TAF/utils/scripts/docker/x86_64.env
+++ b/TAF/utils/scripts/docker/x86_64.env
@@ -1,7 +1,7 @@
 # Image Variables
-virtual=edgexfoundry/docker-device-virtual-go:1.3.0
-mqtt=edgexfoundry/docker-device-mqtt-go:1.3.0
-random=edgexfoundry/docker-device-random-go:1.3.0
-modbus=edgexfoundry/docker-device-modbus-go:1.3.0
+virtual=nexus3.edgexfoundry.org:10004/docker-device-virtual-go:master
+mqtt=nexus3.edgexfoundry.org:10004/docker-device-mqtt-go:master
+random=nexus3.edgexfoundry.org:10004/docker-device-random-go:master
+modbus=nexus3.edgexfoundry.org:10004/docker-device-modbus-go:master
 modbusSimulator=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator:latest
-appService=edgexfoundry/docker-app-service-configurable:1.3.0
+appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master


### PR DESCRIPTION
Because the 1.3.0 is tagged, revert the change on PR #229.