### PR TITLE
Update core-data V2 tests to use resourceName and profileName

### DIFF
--- a/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
@@ -157,7 +157,7 @@ Create Events
 # generate data for core-data
 Generate event sample
     # event_data: Event, Event With Tags ; readings_type: Simple Reading, Simple Float Reading, Binary Reading
-    [arguments]  ${event_data}  ${deviceName}  @{readings_type}
+    [arguments]  ${event_data}  ${deviceName}  ${profileName}  @{readings_type}
     ${uuid}=  Evaluate  str(uuid.uuid4())
     ${millisec_epoch_time}=  Get current milliseconds epoch time
     ${origin}=  Evaluate  int(${millisec_epoch_time}*1000000)
@@ -166,10 +166,12 @@ Generate event sample
         ${reading}=  Load data file "core-data/readings_data.json" and get variable "${type}"
         Set to dictionary  ${reading}  origin=${origin}
         Set to dictionary  ${reading}  deviceName=${deviceName}
+        Set to dictionary  ${reading}  profileName=${profileName}
         Append to List  ${readings}  ${reading}
     END
     ${event}=  Load data file "core-data/event_data.json" and get variable "${event_data}"
     Set to dictionary  ${event}[event]  deviceName=${deviceName}
+    Set to dictionary  ${event}[event]  profileName=${profileName}
     Set to dictionary  ${event}[event]  id=${uuid}
     Set to dictionary  ${event}[event]  origin=${origin}
     Set to dictionary  ${event}[event]  readings=${readings}
@@ -184,14 +186,14 @@ Change ${event} readings[${index}] values ${property_dict}
     END
 
 Generate multiple events sample with simple readings
-    ${event1}=  Generate event sample  Event  Device-Test-001  Simple Reading
-    ${event2}=  Generate event sample  Event  Device-Test-001  Simple Float Reading
-    ${event3}=  Generate event sample  Event  Device-Test-001  Simple Reading  Simple Float Reading
-    ${event4}=  Generate event sample  Event With Tags  Device-Test-001  Simple Reading  Simple Float Reading
+    ${event1}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Simple Reading
+    ${event2}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Simple Float Reading
+    ${event3}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Simple Reading  Simple Float Reading
+    ${event4}=  Generate event sample  Event With Tags  Device-Test-001  Profile-Test-001  Simple Reading  Simple Float Reading
     ${events}=  Create List  ${event1}  ${event2}  ${event3}  ${event4}
     Set test variable  ${events}  ${events}
 
 Generate an event sample with simple readings
-    ${event}=  Generate event sample  Event  Device-Test-001  Simple Reading  Simple Float Reading
+    ${event}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Simple Reading  Simple Float Reading
     ${events}=  Create List  ${event}
     Set test variable  ${events}  ${events}

--- a/TAF/testData/core-data/event_data.json
+++ b/TAF/testData/core-data/event_data.json
@@ -2,6 +2,7 @@
   "Event": {
     "event": {
       "deviceName": "",
+      "profileName": "",
       "id": "",
       "origin": 0,
       "readings": ""
@@ -10,6 +11,7 @@
   "Event With Tags": {
     "event": {
       "deviceName": "",
+      "profileName": "",
       "id": "",
       "origin": 0,
       "readings": "",

--- a/TAF/testData/core-data/readings_data.json
+++ b/TAF/testData/core-data/readings_data.json
@@ -1,21 +1,16 @@
 {
   "Simple Reading": {
     "deviceName": "Device-001",
-    "name": "Simple Reading",
-    "labels": [
-      "simple"
-    ],
+    "resourceName": "Simple Reading",
+    "profileName": "Profile-001",
     "origin": 0,
     "valueType": "Int8",
     "value": "3"
   },
   "Simple Float Reading": {
     "deviceName": "Device-001",
-    "name": "Simple Float Reading",
-    "labels": [
-      "simple",
-      "float"
-    ],
+    "resourceName": "Simple Float Reading",
+    "profileName": "Profile-001",
     "origin": 0,
     "valueType": "Float32",
     "floatEncoding": "eNotation",
@@ -23,10 +18,8 @@
   },
   "Binary Reading": {
     "deviceName": "Device-001",
-    "name": "Binary Reading",
-    "labels": [
-      "binary"
-    ],
+    "resourceName": "Binary Reading",
+    "profileName": "Profile-001",
     "origin": 0,
     "mediaType": "image",
     "valueType": "Binary",

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
@@ -23,7 +23,7 @@ ErrEventPOST001 - Create events fails (Event ID Conflict)
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrEventPOST002 - Create events fails (Bad Events)
-    ${bad_property}=  Create List  no_event  no_deviceName  no_origin  no_readings  no_id  bad_id
+    ${bad_property}=  Create List  no_event  no_deviceName  no_profileName  no_origin  no_readings  no_id  bad_id
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Event With ${property}
          And Create Events
@@ -33,7 +33,7 @@ ErrEventPOST002 - Create events fails (Bad Events)
     END
 
 ErrEventPOST003 - Create events fails (Bad Simple Readings)
-    ${bad_property}=  Create List  no_deviceName  no_name  no_origin  no_valueType  bad_valueType  no_value  no_FloatEncoding
+    ${bad_property}=  Create List  no_deviceName  no_resourceName  no_profileName  no_origin  no_valueType  bad_valueType  no_value
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Simple Reading With ${property}
          And Create Events
@@ -76,7 +76,7 @@ Generate Bad Simple Reading With ${property}
     ...    ELSE     Set to dictionary  ${events}[0][event][readings][0]  ${no_property}=${EMPTY}
 
 Generate Bad Binary Reading With ${property}
-    ${event}=  Generate event sample  Event  Device-Test-001  Binary Reading
+    ${event}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Binary Reading
     ${events}=  Create List  ${event}
     Set test variable  ${events}  ${events}
     ${no_property}=  Fetch From Right  ${property}  no_

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-positive.robot
@@ -33,8 +33,8 @@ EventPOST002 - Create event with binary data
 
 *** Keywords ***
 Generate Multiple Events Sample With Binary Readings
-    ${event1}=  Generate event sample  Event  Device-Test-001  Binary Reading
-    ${event2}=  Generate event sample  Event With Tags  Device-Test-002  Binary Reading  Binary Reading
+    ${event1}=  Generate event sample  Event  Device-Test-001  Profile-Test-001  Binary Reading
+    ${event2}=  Generate event sample  Event With Tags  Device-Test-002  Profile-Test-002  Binary Reading  Binary Reading
     ${events}=  Create List  ${event1}  ${event2}
     Set test variable  ${events}  ${events}
 


### PR DESCRIPTION
fix #234 
1. repalace name with resourceName and add profileName in reading data
2. remove labels in reading data
3. add profileName in event data
3. remove reading negative testcase: no floatEncoding

Signed-off-by: Ginny Guan <ginny@iotechsys.com>