### PR TITLE
Use MQTTSecretSend instead of MQTTSend for app-service-mqtt-export

### DIFF
--- a/TAF/utils/scripts/docker/docker-compose-end-to-end.yaml
+++ b/TAF/utils/scripts/docker/docker-compose-end-to-end.yaml
@@ -44,7 +44,8 @@
       Database_Username: appservice
       Database_Password: password
       EDGEX_SECURITY_SECRET_STORE: "false"
-      Writable_Pipeline_Functions_MQTTSend_Addressable_Address: mqtt-broker
+      Writable.Pipeline.Functions.MQTTSecretSend.Parameters.brokeraddress: tcp://mqtt-broker:1883
+      Writable_Pipeline_Functions_MQTTSecretSend_Parameters_topic: edgex-events
       Writable_LogLevel: DEBUG
     depends_on:
       - consul


### PR DESCRIPTION
Use MQTTSecretSend instead of MQTTSend for app-service-mqtt-export
Signed-off-by: Cherry Wang <cherry@iotechsys.com>