### PR TITLE
Update deviceprofile and reading test data

### DIFF
--- a/TAF/testData/core-data/readings_data.json
+++ b/TAF/testData/core-data/readings_data.json
@@ -1,7 +1,7 @@
 {
   "Simple Reading": {
     "deviceName": "Device-001",
-    "resourceName": "Simple Reading",
+    "resourceName": "Simple-Reading",
     "profileName": "Profile-001",
     "origin": 0,
     "valueType": "Int8",
@@ -9,7 +9,7 @@
   },
   "Simple Float Reading": {
     "deviceName": "Device-001",
-    "resourceName": "Simple Float Reading",
+    "resourceName": "Simple-Float-Reading",
     "profileName": "Profile-001",
     "origin": 0,
     "valueType": "Float32",
@@ -18,7 +18,7 @@
   },
   "Binary Reading": {
     "deviceName": "Device-001",
-    "resourceName": "Binary Reading",
+    "resourceName": "Binary-Reading",
     "profileName": "Profile-001",
     "origin": 0,
     "mediaType": "image",

--- a/TAF/testData/core-metadata/deviceprofile/Test-Profile-1.yaml
+++ b/TAF/testData/core-metadata/deviceprofile/Test-Profile-1.yaml
@@ -14,7 +14,7 @@ deviceResources:
     description: "Generate device boolean value"
     tag: "status"
     properties:
-      type: "BOOL"
+      type: "Bool"
       readWrite: "RW"
       minimum: "0"
       maximum: "1"
@@ -23,7 +23,7 @@ deviceResources:
     description: "Generate device UINT8 value"
     tag: "temperature"
     properties:
-      type: "UINT8"
+      type: "Uint8"
       readWrite: "R"
       units: "degreesFarenheit"
 

--- a/TAF/testData/core-metadata/deviceprofile/Test-Profile-2.yaml
+++ b/TAF/testData/core-metadata/deviceprofile/Test-Profile-2.yaml
@@ -14,13 +14,13 @@ deviceResources:
     description: "Generate device string value"
     tag: "kind"
     properties:
-      type: "STRING"
+      type: "String"
       readWrite: "R"
   - name: "DeviceValue_FLOAT32_R"
     description: "Generate device FLOAT32 value"
     tag: "speed"
     properties:
-      type: "FLOAT32"
+      type: "Float32"
       readWrite: "R"
       floatEncoding: "Base64"
       scale: "0.001"

--- a/TAF/testData/core-metadata/deviceprofile/Test-Profile-3.yaml
+++ b/TAF/testData/core-metadata/deviceprofile/Test-Profile-3.yaml
@@ -13,7 +13,7 @@ deviceResources:
     description: "Generate device FLOAT32 value"
     tag: "humidity"
     properties:
-      type: "FLOAT32"
+      type: "Float32"
       readWrite: "R"
       units: "%"
 

--- a/TAF/testData/core-metadata/deviceprofile/Test-Profile-4.yaml
+++ b/TAF/testData/core-metadata/deviceprofile/Test-Profile-4.yaml
@@ -13,7 +13,7 @@ deviceResources:
     description: "Generate device UINT16 value"
     tag: "rpm"
     properties:
-      type: "UINT16"
+      type: "Uint16"
       readWrite: "RW"
       minimum: "1500"
       units: "rpm"

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
@@ -30,7 +30,7 @@ ProfilePUT002 - Update multiple device profiles
     Given Generate Multiple Device Profiles Sample
     And Create device profile ${deviceProfile}
     And Set To Dictionary  ${deviceProfile}[0][profile]   model=Model_ABC
-    And Set To Dictionary  ${deviceProfile}[1][profile][deviceResources][1][properties]  type=FLOAT64
+    And Set To Dictionary  ${deviceProfile}[1][profile][deviceResources][1][properties]  type=Float64
     And Set To Dictionary  ${deviceProfile}[2][profile][coreCommands][0]  put=${true}
     When Update Device Profile ${deviceProfile}
     Then Should Return Status Code "207"
@@ -59,6 +59,6 @@ Profile ${device_profile_name} Data "${property}" Should Be Updated
     Run Keyword IF  "${property}" == "manufacturer"  Should Be Equal  ${content}[profile][manufacturer]  Mfr_ABC
     ...    ELSE IF  "${property}" == "model"  Should Be Equal  ${content}[profile][model]  Model_ABC
     ...    ELSE IF  "${property}" == "deviceResources-properties"
-    ...             Should Be Equal  ${content}[profile][deviceResources][1][properties][type]  FLOAT64
+    ...             Should Be Equal  ${content}[profile][deviceResources][1][properties][type]  Float64
     ...    ELSE IF  "${property}" == "coreCommands"  Should Be Equal  ${content}[profile][coreCommands][0][put]  ${true}
 

--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -21,19 +21,13 @@ else
   if [ "$SECURITY_SERVICE_NEEDED" = true ]; then
     docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
-          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${BACKWARD}.yaml" up -d security-secrets-setup vault
+          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${BACKWARD}.yaml" up -d security-bootstrapper vault
 
     sleep 20
 
     docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
           -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${BACKWARD}.yaml" up -d vault-worker kong-db
-
-    sleep 10
-
-    docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
-          --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
-          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${BACKWARD}.yaml" up -d kong-migrations
 
     sleep 10
 


### PR DESCRIPTION
Fix https://github.com/edgexfoundry/edgex-taf/issues/252
1. update all deviceprofile properties type to camel case format for consistency
2. update reading resourceName to use hyphen instead of space
3. replace security-secrets-setup with security-bootstrapper and remove kong-migrations in deploy-edgex.sh

Signed-off-by: Ginny Guan <ginny@iotechsys.com>