### PR TITLE
Use received timestamp instead of pushed timestamp

### DIFF
--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/5_event_exported_time/event_exported_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/5_event_exported_time/event_exported_time.robot
@@ -13,7 +13,7 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/performance-metric-collecti
 *** Test Cases ***
 Measure the event exported time
     Given Deploy EdgeX  -  PerformanceMetrics  -mqtt
-    When query events
+    When Retrieve Events From Subscriber
     And fetch the exported time
     Then Run keyword and continue on failure  exported time is less than threshold value
     And show the summary table

--- a/TAF/utils/src/setup/mqtt-subscriber.py
+++ b/TAF/utils/src/setup/mqtt-subscriber.py
@@ -3,6 +3,7 @@
 Origin : https://www.ev3dev.org/docs/tutorials/sending-and-receiving-messages-with-mqtt/
 """
 import paho.mqtt.client as mqtt
+import time
 
 
 # This is the Subscriber
@@ -13,6 +14,8 @@ def on_connect(client, userdata, flags, rc):
 
 
 def on_message(client, userdata, msg):
+    current_timestamp = int(round(time.time() * 1000))
+    print(current_timestamp)
     print(msg.payload.decode())
     if "origin" in msg.payload.decode():
         print("Got mqtt export data!!")


### PR DESCRIPTION
Retrieve the timestamp while receiving the event on the subscriber, and use it instead of push time.

Fix #260 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>