### PR TITLE
Update mqtt subscriber to not disconnect after receiving a message

### DIFF
--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
@@ -34,7 +34,7 @@ Export001 - Export events/readings to HTTP Server
 Export002 - Export events/readings to MQTT Server
     [Tags]  SmokeTest
     Given Deploy services  mqtt-broker
-    And Start process  python ${WORK_DIR}/TAF/utils/src/setup/mqtt-subscriber.py &   # Process for MQTT Subscriber
+    And Start process  python ${WORK_DIR}/TAF/utils/src/setup/mqtt-subscriber.py arg &   # Process for MQTT Subscriber
     ...                shell=True  stdout=${WORK_DIR}/TAF/testArtifacts/logs/mqtt-subscriber.log
     And Deploy services  app-service-mqtt-export
     And Create device  create_device.json

--- a/TAF/utils/src/setup/mqtt-subscriber.py
+++ b/TAF/utils/src/setup/mqtt-subscriber.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
 Origin : https://www.ev3dev.org/docs/tutorials/sending-and-receiving-messages-with-mqtt/
+MQTT Subscriber
 """
 import paho.mqtt.client as mqtt
 import time
+import sys
 
-
-# This is the Subscriber
 
 def on_connect(client, userdata, flags, rc):
     print("Connected to MQTT with result code " + str(rc))
@@ -19,7 +19,8 @@ def on_message(client, userdata, msg):
     print(msg.payload.decode())
     if "origin" in msg.payload.decode():
         print("Got mqtt export data!!")
-        client.disconnect()
+        if sys.argv[1] != 'perf':
+            client.disconnect()
 
 
 client = mqtt.Client()
@@ -28,4 +29,9 @@ client.connect("localhost", 1883, 60)
 client.on_connect = on_connect
 client.on_message = on_message
 
-client.loop_forever()
+if sys.argv[1] != 'perf':
+    client.loop_forever()
+else:
+    client.loop_start()
+    time.sleep(180)
+    client.loop_stop()


### PR DESCRIPTION
1. Add argument while running mqtt-subscriber to use different loop function.
2. Modify the function when reading the subscriber log.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>