### PR TITLE
Update edgex-proxy and vault-worker service name

### DIFF
--- a/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
@@ -8,10 +8,11 @@ Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 
 *** Keywords ***
 Setup Suite for App Service
-    [Arguments]  ${appServiceUrl}
+    [Arguments]  ${appServiceUrl}  ${app_service_name}
     Setup Suite
     Set Suite Variable  ${url}  ${appServiceUrl}
-    Deploy services  app-service-${edgex_profile}
+    Set Suite Variable  ${app_service_name}  ${app_service_name}
+    Deploy services  ${app_service_name}
     Check app-service is available
     Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 
@@ -21,11 +22,11 @@ Check app-service is available
 
 Suite Teardown for App Service
     Suite Teardown
-    Remove services  app-service-${edgex_profile}
+    Remove services  ${app_service_name}
     Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
 
 Set Functions ${functions}
-    ${path}=  Set variable  /v1/kv/edgex/appservices/1.0/AppService-${edgex_profile}/Writable/Pipeline/ExecutionOrder
+    ${path}=  Set variable  /v1/kv/edgex/appservices/1.0/AppService-blackbox-tests/Writable/Pipeline/ExecutionOrder
     Modify consul config  ${path}  ${functions}
     sleep  1
 

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/info/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/info/GET.robot
@@ -1,14 +1,13 @@
 *** Settings ***
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource  TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
-Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}
+Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}  app-service-blackbox-tests
 Suite Teardown   Suite Teardown for App Service
 Force Tags       v2-api
 
 *** Variables ***
 ${SUITE}          App-Service GET Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-get.log
-${edgex_profile}  blackbox-tests
 ${AppServiceUrl_blackbox}  http://${BASE_URL}:48105
 ${api_version}  v2
 

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
@@ -44,16 +44,14 @@ ErrSecretsPOST004 - Stores secrets to the secret client fails (security not enab
 
 *** Keywords ***
 Setup Suite for App Service Secrets
-    Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Run Keywords
+    Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'
     #EDGEX_SECURITY_SECRET_STORE: "true"
-    ...             Set Suite Variable  ${edgex_profile}  http-export-secrets
-    ...             AND  Setup Suite for App Service  http://${BASE_URL}:48102
+    ...             Setup Suite for App Service  http://${BASE_URL}:48102  app-service-http-export-secrets
     #EDGEX_SECURITY_SECRET_STORE: "false"
-    ...             ELSE  Run keywords  Set Suite Variable  ${edgex_profile}  http-export
-    ...             AND  Setup Suite for App Service  http://${BASE_URL}:48101
+    ...             ELSE  Setup Suite for App Service  http://${BASE_URL}:48101  app-service-http-export
 
 Get AppService Token
-    ${command}=  Set Variable  docker exec app-service-${edgex_profile} cat /tmp/edgex/secrets/appservice-${edgex_profile}/secrets-token.json
+    ${command}=  Set Variable  docker exec ${app_service_name} cat /tmp/edgex/secrets/${app_service_name}/secrets-token.json
     ${result} =  Run Process  ${command}  shell=yes  output_encoding=UTF-8
     ${result_string}=  Evaluate  json.loads('''${result.stdout}''')  json
     Set Test Variable  ${token}  ${result_string}[auth][client_token]
@@ -62,7 +60,7 @@ Secrets Should be Stored
     Get AppService Token
     Create Session  GetSecrets  url=http://${BASE_URL}:8200  disable_warnings=true
     ${headers}=  Create Dictionary  X-Vault-Token  ${token}
-    ${resp}=  GET On Session  GetSecrets  /v1/secret/edgex/appservice-${edgex_profile}/${secrets_path}  headers=${headers}
+    ${resp}=  GET On Session  GetSecrets  /v1/secret/edgex/${app_service_name}/${secrets_path}  headers=${headers}
     ...       expected_status=200
     Set Response to Test Variables  ${resp}
     Should Contain  ${content}[data]  ${secrets_key}  ${secrets_value}

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-negative.robot
@@ -2,14 +2,13 @@
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource  TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
 Library   TAF/testCaseModules/keywords/consul/consul.py
-Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}
+Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}  app-service-blackbox-tests
 Suite Teardown   Suite Teardown for App Service
 Force Tags       v2-api
 
 *** Variables ***
 ${SUITE}          App-Service Trigger POST Negative Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-trigger-negative.log
-${edgex_profile}  blackbox-tests
 ${AppServiceUrl_blackbox}  http://${BASE_URL}:48105
 ${api_version}  v2
 
@@ -31,7 +30,7 @@ ErrTriggerPOST002 - Trigger pipeline fails (Unprocessable Entity)
 *** Keywords ***
 Accept raw data
     [arguments]  ${bool}
-    ${path}=  Set variable  /v1/kv/edgex/appservices/1.0/AppService-${edgex_profile}/Writable/Pipeline/UseTargetTypeOfByteArray
+    ${path}=  Set variable  /v1/kv/edgex/appservices/1.0/AppService-blackbox-tests/Writable/Pipeline/UseTargetTypeOfByteArray
     Modify consul config  ${path}  ${bool}
     sleep  1
 

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
@@ -2,14 +2,13 @@
 Resource   TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource   TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
 Variables  TAF/testData/app-service/trigger_response_content.py
-Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}
+Suite Setup      Setup Suite for App Service  ${AppServiceUrl_blackbox}  app-service-blackbox-tests
 Suite Teardown   Suite Teardown for App Service
 Force Tags       v2-api
 
 *** Variables ***
 ${SUITE}          App-Service Trigger POST Positive Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-trigger-positive.log
-${edgex_profile}  blackbox-tests
 ${AppServiceUrl_blackbox}  http://${BASE_URL}:48105
 ${api_version}  v2
 

--- a/TAF/utils/scripts/docker/api-gateway-token.sh
+++ b/TAF/utils/scripts/docker/api-gateway-token.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 option=${1}
-PROXY_IMAGE=$(docker inspect --format='{{.Config.Image}}' edgex-proxy)
-PROXY_NETWORK_ID=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}' edgex-proxy)
+PROXY_IMAGE=$(docker inspect --format='{{.Config.Image}}' edgex-proxy-setup)
+PROXY_NETWORK_ID=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}' edgex-proxy-setup)
 
 if [ ! -f "${WORK_DIR}/ec256.pub" ];
 then

--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -21,11 +21,11 @@ else
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
           -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d security-bootstrapper vault
 
-    sleep 20
+    sleep 10
 
     docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
-          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d vault-worker kong-db
+          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d secretstore-setup kong-db consul
 
     sleep 10
 
@@ -37,13 +37,13 @@ else
 
     docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
-          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d edgex-proxy
+          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up -d proxy-setup
   fi
 
   docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
           -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up \
-          -d database consul data metadata command notifications scheduler
+          -d database data metadata command notifications scheduler
   sleep 5
 
 fi


### PR DESCRIPTION
Based on [developer-script #372](https://github.com/edgexfoundry/developer-scripts/pull/372) to update scripts.
1. Modify service name from `edgex-proxy` to `proxy-setup` and `vault-worker` to `secretstore-setup`.
2. Modify `appservice-http-export-secrets` to `app-service-http-export-secrets`  for SECRETSTORE Path.

Fix #271 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>