### PR TITLE
Add delete all session on teardown for test suites

### DIFF
--- a/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
@@ -23,7 +23,7 @@ Check app-service is available
 Suite Teardown for App Service
     Suite Teardown
     Remove services  ${app_service_name}
-    Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+    Run Teardown Keywords
 
 Set Functions ${functions}
     ${path}=  Set variable  /v1/kv/edgex/appservices/1.0/AppService-functional-tests/Writable/Pipeline/ExecutionOrder

--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -16,6 +16,10 @@ Setup Suite
    ${status} =  Suite Setup  ${SUITE}  ${LOG_FILE_PATH}  ${LOG_LEVEL}
    Should Be True  ${status}  Failed Suite Setup
 
+Run Teardown Keywords
+    Delete All Sessions  # Delete http or https request sessions
+    Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+
 Skip write only commands
     @{data_types_skip_write_only}=    Create List
     FOR    ${item}    IN    @{SUPPORTED_DATA_TYPES}

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-negative.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/POST-positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/info/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/info/GET.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/DELETE.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/DELETE.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive-II.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative-II.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/PATCH-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative-II.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Negative.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/device/POST-Positive.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Negative.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/DELETE-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive-II.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive-II.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Uploadfile.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Uploadfile.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/DELETE-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/PATCH-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/POST-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/POST-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/info/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/info/GET.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/DELETE.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/DELETE.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags  v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags   v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags   v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/PATCH.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/PATCH.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/POST-Negative.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/POST-Positive.robot
@@ -3,7 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
 *** Variables ***

--- a/TAF/testScenarios/functionalTest/device-service/common/3_device_profile/3_device_profile.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/3_device_profile/3_device_profile.robot
@@ -4,7 +4,7 @@ Resource  TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}              Device

--- a/TAF/testScenarios/functionalTest/device-service/common/4_device/4_device.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/4_device/4_device.robot
@@ -4,7 +4,7 @@ Resource  TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}              Device

--- a/TAF/testScenarios/functionalTest/device-service/common/5_query_commands/5_query_commands.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/5_query_commands/5_query_commands.robot
@@ -10,7 +10,7 @@ Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 ...                        AND  Create device  create_device.json
 Suite Teardown  Run Keywords  Delete device by name
-...                           AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+...                           AND  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}              Query Commands

--- a/TAF/testScenarios/functionalTest/device-service/common/6_scheduling/6_scheduling.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/6_scheduling/6_scheduling.robot
@@ -7,7 +7,7 @@ Resource  TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}              Scheduling

--- a/TAF/testScenarios/functionalTest/device-service/common/7_actuation_commands/7_actuation_commands.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/7_actuation_commands/7_actuation_commands.robot
@@ -9,7 +9,7 @@ Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 ...                        AND  Create device  create_device.json
 Suite Teardown  Run Keywords  Delete device by name
-...                           AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+...                           AND  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}        Actuation Commands

--- a/TAF/testScenarios/functionalTest/device-service/common/8_metadata_updates/8_metadata_updates.robot
+++ b/TAF/testScenarios/functionalTest/device-service/common/8_metadata_updates/8_metadata_updates.robot
@@ -6,7 +6,7 @@ Resource  TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
 Resource  TAF/testCaseModules/keywords/common/commonKeywords.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
-Suite Teardown  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+Suite Teardown  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}        Metadata Update

--- a/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
+++ b/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
@@ -11,7 +11,7 @@ Suite Setup      Run keywords   Setup Suite
 Suite Teardown   Run keywords   Remove services  device-virtual
 ...                             AND  Delete device by name Test-Device
 ...                             AND  Delete device profile by name  Sample-Profile
-...                             AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+...                             AND  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}         Clean Up Events/Readings By Scheduler

--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
@@ -12,7 +12,7 @@ Suite Setup      Run keywords   Setup Suite
 ...                             AND  Deploy device service  device-virtual
 Suite Teardown   Run keywords   Remove services  device-virtual
 ...                             AND  Delete device profile by name  Sample-Profile
-...                             AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Remove Token
+...                             AND  Run Teardown Keywords
 
 *** Variables ***
 ${SUITE}         Export data to backend


### PR DESCRIPTION
Add keyword `Delete All Session` on suite teardown.

Fix #292 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>