### PR TITLE
Replace milliseconds with nanoseconds

### DIFF
--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -129,6 +129,11 @@ Get current milliseconds epoch time
     ${millisec_epoch_time}=    evaluate   int(${current_epoch_time}*1000)
     [Return]  ${millisec_epoch_time}
 
+Get current nanoseconds epoch time
+    ${current_epoch_time}=  Get current epoch time
+    ${nonosec_epoch_time}=    evaluate   int(${current_epoch_time}*1000*1000000)
+    [Return]  ${nonosec_epoch_time}
+
 Get current epoch time
     ${data}=  get current date
     ${current_epoch_time}=  convert date    ${data}  epoch

--- a/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
@@ -250,8 +250,7 @@ Generate event sample
     # event_data: Event, Event With Tags ; readings_type: Simple Reading, Simple Float Reading, Binary Reading
     [arguments]  ${event_data}  ${deviceName}  ${profileName}  ${sourceName}  @{readings_type}
     ${uuid}=  Evaluate  str(uuid.uuid4())
-    ${millisec_epoch_time}=  Get current milliseconds epoch time
-    ${origin}=  Evaluate  int(${millisec_epoch_time}*1000000)
+    ${origin}=  Get current nanoseconds epoch time
     @{readings}=  Create List
     FOR  ${type}  IN  @{readings_type}
         ${reading}=  Load data file "core-data/readings_data.json" and get variable "${type}"
@@ -280,9 +279,9 @@ Create multiple events
   END
 
 Create multiple events twice to get start/end time
-  ${start_time}=  Get current milliseconds epoch time
+  ${start_time}=  Get current nanoseconds epoch time
   Create Multiple Events
-  ${end_time}=  Get current milliseconds epoch time
+  ${end_time}=  Get current nanoseconds epoch time
   Create Multiple Events
   Set Test Variable  ${start_time}  ${start_time}
   Set Test Variable  ${end_time}  ${end_time}

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
@@ -57,9 +57,9 @@ Events With Specified Device Should Be Deleted
 
 Create Multiple Events For Deleting By Age
   Create Multiple Events
-  ${before_time}=  Get current milliseconds epoch time
+  ${before_time}=  Get current nanoseconds epoch time
   Create Multiple Events
-  ${after_time}=  Get current milliseconds epoch time
+  ${after_time}=  Get current nanoseconds epoch time
   ${age}=  Evaluate  ${after_time} - ${before_time}
   Set Test Variable  ${age}  ${age}
 

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-negative.robot
@@ -27,22 +27,22 @@ ErrEventGET002 - Query event by ID fails (Not UUID)
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrEventGET003 - Query events by start/end time fails (Invalid Start)
-    ${end_time}=  Get current milliseconds epoch time
+    ${end_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Events By Start/End Time  InvalidStart  ${end_time}
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrEventGET004 - Query events by start/end time fails (Invalid End)
-    ${start_time}=  Get current milliseconds epoch time
+    ${start_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Events By Start/End Time  ${start_time}  InvalidEnd
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrEventGET005 - Query events by start/end time fails (Start>End)
-    ${start_time}=  Get current milliseconds epoch time
-    ${end_time}=  Get current milliseconds epoch time
+    ${start_time}=  Get current nanoseconds epoch time
+    ${end_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Events By Start/End Time  ${end_time}  ${start_time}
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/GET-positive.robot
@@ -83,5 +83,5 @@ Events Should Be Created Between ${start} And ${end}
   ${count}=  Get Length  ${content}[events]
   Should Be Equal As Integers  ${count}  6
   FOR  ${index}  IN RANGE  0  6
-    Should Be True  ${end} >= ${content}[events][${index}][created] >=${start}
+    Should Be True  ${end} >= ${content}[events][${index}][origin] >=${start}
   END

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-negative.robot
@@ -45,22 +45,22 @@ ErrReadingGET005 - Query all readings with invalid offset range
     [Teardown]  Delete All Events By Age
 
 ErrReadingGET006 - Query readings by start/end time fails (Invalid Start)
-    ${end_time}=  Get current milliseconds epoch time
+    ${end_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Readings By Start/End Time  InvalidStart  ${end_time}
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrReadingGET007 - Query readings by start/end time fails (Invalid End)
-    ${start_time}=  Get current milliseconds epoch time
+    ${start_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Readings By Start/End Time  ${start_time}  InvalidEnd
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrReadingGET008 - Query readings by start/end time fails (Start>End)
-    ${start_time}=  Get current milliseconds epoch time
-    ${end_time}=  Get current milliseconds epoch time
+    ${start_time}=  Get current nanoseconds epoch time
+    ${end_time}=  Get current nanoseconds epoch time
     When Run Keyword And Expect Error  *  Query Readings By Start/End Time  ${end_time}  ${start_time}
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"

--- a/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/reading/GET-positive.robot
@@ -89,5 +89,5 @@ Readings Should Be Created Between ${start} And ${end}
   ${count}=  Get Length  ${content}[readings]
   Should Be Equal As Integers  ${count}  9
   FOR  ${index}  IN RANGE  0  9
-    Should Be True  ${end} >= ${content}[readings][${index}][created] >=${start}
+    Should Be True  ${end} >= ${content}[readings][${index}][origin] >=${start}
   END


### PR DESCRIPTION
Replace milliseconds with nanoseconds when querying event/reading by start/end time
Fix #348
Signed-off-by: Cherry Wang <cherry@iotechsys.com>