### PR TITLE
Add waiting time to avoid the age calculating incorrectly for the test of delete event by age API

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-data/event/DELETE-positive.robot
@@ -58,6 +58,7 @@ Events With Specified Device Should Be Deleted
 Create Multiple Events For Deleting By Age
   Create Multiple Events
   ${before_time}=  Get current nanoseconds epoch time
+  sleep  1s
   Create Multiple Events
   ${after_time}=  Get current nanoseconds epoch time
   ${age}=  Evaluate  ${after_time} - ${before_time}


### PR DESCRIPTION
The unit of age is by nanosecond. If the calculating time is too close, that is easy to delete the event that we want to keep.
Add waiting time between the age calculated value to avoid the age calculating incorrectly.
#348
Signed-off-by: Cherry Wang <cherry@iotechsys.com>