### PR TITLE
Use app-service-http-export instead of app-service-http-export-secure

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
@@ -43,12 +43,8 @@ ErrSecretsPOST004 - Stores secrets to the secret client fails (security not enab
 
 *** Keywords ***
 Setup Suite for App Service Secrets
-    Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Run Keywords
-    #EDGEX_SECURITY_SECRET_STORE: "true"
-    ...             Set Suite Variable  ${app_service_name}  app-service-http-export-secrets
-    ...        AND  Setup Suite for App Service  http://${BASE_URL}:48102
-    #EDGEX_SECURITY_SECRET_STORE: "false"
-    ...             ELSE  Setup Suite for App Service  http://${BASE_URL}:48101
+    Set Suite Variable  ${app_service_name}  app-http-export
+    Setup Suite for App Service  http://${BASE_URL}:48101
 
 Get AppService Token
     ${command}=  Set Variable  docker exec ${app_service_name} cat /tmp/edgex/secrets/${app_service_name}/secrets-token.json

--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -3,8 +3,6 @@
 TEST_STRATEGY=${1:-}
 APPSERVICE=${2:-}
 
-[ "$SECURITY_SERVICE_NEEDED" = true ] && HTTP_SECTY="app-service-http-export-secrets"
-
 if [ "$TEST_STRATEGY" = "PerformanceMetrics" ]; then
   # temporary fix
   docker run --rm -v ${WORK_DIR}:${WORK_DIR}:rw,z -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
@@ -46,7 +44,5 @@ else
           --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable ${COMPOSE_IMAGE} \
           -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" up \
           -d data metadata command notifications scheduler app-service-functional-tests \
-          app-service-http-export ${HTTP_SECTY}
-  sleep 5
-
+          app-service-http-export
 fi


### PR DESCRIPTION
Use app-service-http-export instead of app-service-http-export-secure.

Fix #365 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>