### PR TITLE
Update functional-test notices for launching edgex without compose file

### DIFF
--- a/TAF/config/global_variables.py
+++ b/TAF/config/global_variables.py
@@ -19,6 +19,7 @@ BASE_URL = "localhost"
 # Service port
 APP_HTTP_EXPORT_PORT = 48101
 APP_MQTT_EXPORT_PORT = 48103
+APP_FUNCTIOAL_TESTS_PORT = 48105
 REGISTRY_PORT = 8500
 jwt_token = ''
 consul_token = ''

--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -155,7 +155,7 @@ Get current epoch time
     [Return]  ${current_epoch_time}
 
 Get current ISO 8601 time
-    ${current_date}  get current date
+    ${current_date}  get current date  UTC
     ${current_ISO_8601_time}  Convert Date  ${current_date}  result_format=%Y%m%dT%H%M%S
     [Return]  ${current_ISO_8601_time}
 

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/info/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/info/GET.robot
@@ -8,7 +8,7 @@ Force Tags       v2-api
 *** Variables ***
 ${SUITE}          App-Service GET Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-get.log
-${AppServiceUrl_functional}  http://${BASE_URL}:48105
+${AppServiceUrl_functional}  http://${BASE_URL}:${APP_FUNCTIOAL_TESTS_PORT}
 
 *** Test Cases ***
 InfoGET001 - Query ping

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
@@ -44,7 +44,7 @@ ErrSecretsPOST004 - Stores secrets to the secret client fails (security not enab
 *** Keywords ***
 Setup Suite for App Service Secrets
     Set Suite Variable  ${app_service_name}  app-http-export
-    Setup Suite for App Service  http://${BASE_URL}:48101
+    Setup Suite for App Service  http://${BASE_URL}:${APP_HTTP_EXPORT_PORT}
 
 Get AppService Token
     ${command}=  Set Variable  docker exec ${app_service_name} cat /tmp/edgex/secrets/${app_service_name}/secrets-token.json

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-negative.robot
@@ -8,7 +8,7 @@ Force Tags       v2-api
 *** Variables ***
 ${SUITE}          App-Service Trigger POST Negative Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-trigger-negative.log
-${AppServiceUrl_functional}  http://${BASE_URL}:48105
+${AppServiceUrl_functional}  http://${BASE_URL}:${APP_FUNCTIOAL_TESTS_PORT}
 
 *** Test Cases ***
 ErrTriggerPOST001 - Trigger pipeline fails (Invalid Data)

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
@@ -9,7 +9,7 @@ Force Tags       v2-api
 *** Variables ***
 ${SUITE}          App-Service Trigger POST Positive Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/app-service-trigger-positive.log
-${AppServiceUrl_functional}  http://${BASE_URL}:48105
+${AppServiceUrl_functional}  http://${BASE_URL}:${APP_FUNCTIOAL_TESTS_PORT}
 
 *** Test Cases ***
 TriggerPOST001 - Trigger pipeline (no match)

--- a/docs/run-tests-on-local.md
+++ b/docs/run-tests-on-local.md
@@ -79,8 +79,44 @@ Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/
     ```
 3. Run Test
     ###### Run V2 API Functional testing:
+    
+    - For Core Command: Not supported. The script will auto deploy device-virtual through compose file.
+    - For Core Data, Core Metadata, Support Notifications, and Support Scheduler:
     ``` bash
-    python3 -m TUC --exclude Skipped --include v2-api -u functionalTest/V2-API -p default
+    # ${ServiceDir}: Please use the directory name under TAF/testScenarios/functionalTest/V2-API
+    
+    # Run Test Command
+    python3 -m TUC --exclude Skipped --include v2-api -u functionalTest/V2-API/${ServiceDir} -p default
+    ``` 
+    - For APP Service:
+    ``` bash
+    # Consul is required. Scripts will modify the APP Service configuration.
+    # Used 2 profiles, funcational-tests and http-export.
+   
+    # Before launching APP Service, please export the following variables.
+    export EDGEX_SECURITY_SECRET_STORE=false
+    export SERVICE_PORT=48105 (For functional-tests)
+    export SERVICE_PORT=48101 (For http-export)
+   
+    # Run Test Command
+    export SECURITY_SERVICE_NEEDED=false  # Otherwise, will get test ErrSecretsPOST004 failed.
+    python3 -m TUC --exclude Skipped --include v2-api -u functionalTest/V2-API/app-service -p default
+    ```
+    - Device Service:
+    ``` bash
+    # Before launching Device Service, please export the following variables.
+    export EDGEX_SECURITY_SECRET_STORE=false
+   
+    # Modify the ProfilesDir value on configuration.toml under ${HOME}/edgex-taf/TAF/config/${profile}
+    ProfilesDir = ${HOME}/edgex-taf/TAF/config/${profile}
+   
+    # Launch device service with the confdir parameter 
+    --confdir=${HOME}/edgex-taf/TAF/config/${profile}
+   
+    # Run Test Command
+    python3 -m TUC --exclude Skipped -u functionalTest/device-service -p ${profile}
+    
+    # ${profile}: Use the directory name under TAF/config which depends on what service to test. Examples, device-virtual or device-modbus
     ```
 
     ###### Run Integration testing:


### PR DESCRIPTION
1. Update functional-test notices for launching edgex without compose file.
2. Add a variable of app service port to global_variables.py.

Fix #389 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>