### PR TITLE
Revert "Add scheduler tests to SmokeTest for kong issue"

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
@@ -4,7 +4,7 @@ Resource     TAF/testCaseModules/keywords/support-scheduler/supportSchedulerAPI.
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
 Suite Teardown  Run Teardown Keywords
-Force Tags  v2-api  SmokeTest
+Force Tags  v2-api
 
 *** Variables ***
 ${SUITE}          Support Scheduler Intervalaction GET Test Cases


### PR DESCRIPTION
Reverts edgexfoundry/edgex-taf#404, because it blocked [edgexfoundry/edgex-compose #83 ](https://github.com/edgexfoundry/edgex-compose/pull/83)
