### PR TITLE
Add adminState field into test data of intervalaction and subscription

### DIFF
--- a/TAF/testData/support-notifications/subscription_data.json
+++ b/TAF/testData/support-notifications/subscription_data.json
@@ -10,5 +10,6 @@
   ],
   "receiver": "tafuser",
   "resendLimit": 0,
-  "resendInterval": "24h"
+  "resendInterval": "24h",
+  "AdminState": "UNLOCKED"
 }

--- a/TAF/testData/support-scheduler/interval_action.json
+++ b/TAF/testData/support-scheduler/interval_action.json
@@ -7,7 +7,8 @@
             "host": "localhost",
             "port": 48080,
             "httpMethod": "DELETE"
-        }
+        },
+        "AdminState": "UNLOCKED"
     },
     "MQTTAddress": {
         "name" :"MQTTAddress",
@@ -18,7 +19,8 @@
             "port": 1883,
             "publisher": "publisher",
             "topic": "events"
-        }
+        },
+        "AdminState": "UNLOCKED"
     },
     "EmailAddress": {
         "name": "EmailAddress",
@@ -26,6 +28,7 @@
         "address": {
             "type": "EMAIL",
             "recipients": ["test-1@email.com", "test-2@email.com"]
-        }
+        },
+        "AdminState": "UNLOCKED"
     }
 }

--- a/TAF/testScenarios/functionalTest/V2-API/support-notifications/subscription/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-notifications/subscription/PATCH-Negative.robot
@@ -135,3 +135,13 @@ ErrSubscriptionPATCH012 - Update subscription for EMAL channel with invalid form
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete Multiple Subscriptions By Names  @{subscription_names}
+
+ErrSubscriptionPATCH013 - Update subscription with invalid adminState
+    Given Generate A Subscription Sample With EMAIL Channel
+    And Create Subscription ${subscription}
+    And Set To Dictionary  ${subscription}[0][subscription]  adminState=Invalid
+    When Update Subscriptions ${subscription}
+    Then Should Return Status Code "400"
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete Multiple Subscriptions By Names  @{subscription_names}

--- a/TAF/testScenarios/functionalTest/V2-API/support-notifications/subscription/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-notifications/subscription/POST.robot
@@ -101,3 +101,11 @@ ErrSubscriptionPOST009 - Create subscription with empty HTTPMethod for REST chan
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
+ErrSubscriptionPOST010 - Create subscription with invalid adminState
+    Given Generate A Subscription Sample With REST Channel
+    And Set To Dictionary  ${subscription}[0][subscription]  adminState=invalid
+    When Create Subscription ${subscription}
+    Then Should Return Status Code "400"
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+

--- a/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/PATCH-Negative.robot
@@ -167,3 +167,13 @@ ErrIntervalactionPATCH014 - Update intervalaction with empty recipients for EMAI
     And Should Return Content-Type "application/json"
     [Teardown]  Run Keywords  Delete IntervalAction By Name ${intervalAction_name}
     ...         AND  Delete interval by name ${Interval_name}
+
+ErrIntervalactionPATCH015 - Update intervalaction with invalid adminState
+    Given Create An Interval And Generate An Intervalaction Sample  EmailAddress
+    And Create Intervalaction  ${intervalActions}
+    And Set To Dictionary  ${intervalActions}[0][action]  adminState=Invalid
+    When Update IntervalActions  ${intervalActions}
+    Then Should Return Status Code "400"
+    And Should Return Content-Type "application/json"
+    [Teardown]  Run Keywords  Delete IntervalAction By Name ${intervalAction_name}
+    ...         AND  Delete interval by name ${Interval_name}

--- a/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/POST-Negative.robot
@@ -140,3 +140,11 @@ ErrIntervalactionPOST014 - Create intervalaction with empty recipients for EMAIL
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     [Teardown]  Delete interval by name ${Interval_name}
+
+ErrIntervalactionPOST015 - Create intervalaction with invalid adminState
+    Given Create An Interval And Generate An Intervalaction Sample  EmailAddress
+    And Set To Dictionary  ${intervalActions}[0][action]  adminState=Invalid
+    When Create Intervalaction  ${intervalActions}
+    Then Should Return Status Code "400"
+    And Should Return Content-Type "application/json"
+    [Teardown]  Delete interval by name ${Interval_name}


### PR DESCRIPTION
Add adminState field into test data of intervalaction and subscription.

Fix #406 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>