### PR TITLE
Stop app-service for scalability-test service

### DIFF
--- a/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+++ b/TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
@@ -153,7 +153,7 @@ Delete events by device name
 # generate data for core-data
 Generate event sample
     # event_data: Event, Event With Tags ; readings_type: Simple Reading, Simple Float Reading, Binary Reading
-    [arguments]  ${event_data}  ${deviceName}  ${profileName}  ${sourceName}  @{readings_type}
+    [Arguments]  ${event_data}  ${deviceName}  ${profileName}  ${sourceName}  @{readings_type}
     ${uuid}=  Evaluate  str(uuid.uuid4())
     ${origin}=  Get current nanoseconds epoch time
     @{readings}=  Create List

--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
@@ -29,6 +29,7 @@ Export001 - Export events/readings to HTTP Server
 
 Export002 - Export events/readings to MQTT Server
     [Tags]  SmokeTest
+    [Setup]  Stop Services  scalability-test-mqtt-export
     Given Start process  python ${WORK_DIR}/TAF/utils/src/setup/mqtt-subscriber.py arg &   # Process for MQTT Subscriber
     ...                shell=True  stdout=${WORK_DIR}/TAF/testArtifacts/logs/mqtt-subscriber.log
     And Run Keyword If  $SECURITY_SERVICE_NEEDED == 'true'  Store Secret With MQTT Export To Vault

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -33,10 +33,6 @@ if [ "$USE_RELEASE" = "pre-release" ]; then
   sed -i 's/\EXPORT_HOST_PLACE_HOLDER/${DOCKER_HOST_IP}/g' docker-compose.yaml
   sed -i 's/\MQTT_BROKER_ADDRESS_PLACE_HOLDER/${MQTT_BROKER_IP}/g' docker-compose.yaml
   sed -i 's/\LOGLEVEL: INFO/LOGLEVEL: DEBUG/g' docker-compose.yaml
-  if [ "$USE_SECURITY" = "-security-" ]; then
-    sed -i "/ROUTES_RULES_ENGINE_HOST/a \ \ \ \ \ \ ADD_PROXY_ROUTE: 'modbusdevice.http://device-modbus:59901'" \
-    docker-compose.yaml
-  fi
 else
   COMPOSE_FILE="docker-compose-${USE_RELEASE}${USE_NO_SECURITY}${USE_ARM64}.yml"
   curl -o ${COMPOSE_FILE} "https://raw.githubusercontent.com/edgexfoundry/edgex-compose/${USE_RELEASE}/${COMPOSE_FILE}"


### PR DESCRIPTION
1. Stop app-service for scalability-test service.
2. Remove add proxy route for device-modbus, the fix moves to [edgexfoundry/edgex-compose #101](https://github.com/edgexfoundry/edgex-compose/pull/101).

Signed-off-by: Cherry Wang <cherry@iotechsys.com>