### PR TITLE
Replace http with URI_SCHEME variable for kuiper url.

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
@@ -102,3 +102,4 @@ Set MaxResultCount=${number} For Support-Scheduler On Consul
    ${path}=  Set Variable  /v1/kv/edgex/core/${CONSUL_CONFIG_VERSION}/support-scheduler/Service/MaxResultCount
    Update Service Configuration On Consul  ${path}  ${number}
    Restart Services  scheduler
+   sleep  2s

--- a/TAF/testScenarios/integrationTest/UC_kuiper/export_by_kuiper_rules.robot
+++ b/TAF/testScenarios/integrationTest/UC_kuiper/export_by_kuiper_rules.robot
@@ -14,7 +14,7 @@ Suite Teardown   Run Keywords   Delete Stream
 *** Variables ***
 ${SUITE}         Export By Kuiper Rules
 ${LOG_FILE_PATH}          ${WORK_DIR}/TAF/testArtifacts/logs/export_by_kuiper_rules.log
-${kuiperUrl}     http://${BASE_URL}:${RULESENGINE_PORT}
+${kuiperUrl}     ${URI_SCHEME}://${BASE_URL}:${RULESENGINE_PORT}
 
 *** Test Cases ***
 Kuiper001 - Add a new rule and export to MQTT


### PR DESCRIPTION
Replace http with URI_SCHEME variable for kuiper url.
Add sleep time after restart service. 

Signed-off-by: Cherry Wang <cherry@iotechsys.com>