### PR TITLE
fix: Remove retry items of SecretStore config and update secret path

### DIFF
--- a/TAF/config/default/configuration.toml
+++ b/TAF/config/default/configuration.toml
@@ -64,13 +64,11 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/device-virtual/'
+Path = 'device-virtual/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/device-virtual/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/TAF/config/modbus_scalability_test/configuration.toml
+++ b/TAF/config/modbus_scalability_test/configuration.toml
@@ -64,13 +64,11 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/device-modbus/'
+Path = 'device-modbus/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/device-modbus/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 


### PR DESCRIPTION
- go-mod-bootstrap has implemented the addition of prefix /v1/secret/edgex/ for the Path property of SecretStore config section, so we just use the service specific secret path in Toml files
- also retry related item in SecretStore config no longer needed and hence removed

Fix: #449

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

@cherrycl , @cloudxxx8 , @lenny-intel 