### PR TITLE
Remove success field validation in system tests

### DIFF
--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -232,15 +232,14 @@ Query Metrics
 
 Update Service Configuration On Consul
     [Arguments]  ${path}  ${value}
-    Run Keyword If  $SECURITY_SERVICE_NEEDED == 'true'  Get Consul Token
+    ${consul_token}  Run Keyword If  $SECURITY_SERVICE_NEEDED == 'true'  Get Consul Token
     ${headers}=  Create Dictionary  X-Consul-Token=${consul_token}
     ${url}  Set Variable  http://${BASE_URL}:${REGISTRY_PORT}
     Create Session  Consul  url=${url}  disable_warnings=true
     ${resp}=  PUT On Session  Consul  ${path}  data=${value}  headers=${headers}  expected_status=200
-    Set Response to Test Variables  ${resp}
 
 Get Consul Token
     ${command}  Set Variable  docker exec edgex-core-consul cat /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     ${result}  Run Process  ${command}  shell=True  output_encoding=UTF-8
     ${token}  Evaluate  json.loads('''${result.stdout}''')  json
-    Set Test Variable  ${consul_token}  ${token}[SecretID]
+    [Return]  ${token}[SecretID]

--- a/TAF/testCaseModules/keywords/system-agent/systemAgentAPI.robot
+++ b/TAF/testCaseModules/keywords/system-agent/systemAgentAPI.robot
@@ -42,3 +42,8 @@ System Agent Controls Services
     ${resp}=  POST On Session  System Agent  api/${API_VERSION}/system/operation  json=${requests}  headers=${headers}
     ...       expected_status=any
     Set Response to Test Variables  ${resp}
+
+Update MetricsMechanism To ${value} On Consul
+    ${mechanism_path}=  Set Variable  /v1/kv/edgex/core/${CONSUL_CONFIG_VERSION}/sys-mgmt-agent/MetricsMechanism
+    Update Service Configuration On Consul  ${mechanism_path}  ${value}
+    Restart Services  system

--- a/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/GET.robot
@@ -102,4 +102,3 @@ Set MaxResultCount=${number} For Support-Scheduler On Consul
    ${path}=  Set Variable  /v1/kv/edgex/core/${CONSUL_CONFIG_VERSION}/support-scheduler/Service/MaxResultCount
    Update Service Configuration On Consul  ${path}  ${number}
    Restart Services  scheduler
-   sleep  2s

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Negative.robot
@@ -3,6 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/system-agent/systemAgentAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                        AND  Update MetricsMechanism To executor On Consul
 Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
@@ -15,7 +16,7 @@ ErrSysMgmtGET001 - Query metrics of the given services containing non-existent s
     Set Test Variable  ${default_response_time_threshold}  3500   # normally exceed default 1200ms
     When Query Service Metrics  edgex-core-data  non-existent-service  edgex-support-notifications
     Then Should Return Status Code "207"
-    And Should Retrun Success=True For Existent Services And Success=False For Non-Existent Services
+    And Should Retrun 200 and metrics For Existent Services And 500 And metrics=None For Non-Existent Services
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
@@ -34,32 +35,18 @@ ErrSysMgmtGET003 - Query health of the given services containing non-existent se
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrSysMgmtGET004 - Query metrics of the given services containing non-existent services with MetricsMechanism=direct-service
-    ${mechanism_path}=  Set Variable  /v1/kv/edgex/core/${CONSUL_CONFIG_VERSION}/sys-mgmt-agent/MetricsMechanism
-    Given Update Service Configuration On Consul  ${mechanism_path}  direct-service
-    And Restart Services  system
+    Given Update MetricsMechanism To direct-service On Consul
     When Query Service Metrics  non-existent-service  core-metadata
     Then Should Return Status Code "207"
     And Should Retrun 200 And config For Existent Services And 404 And metrics=None For Non-Existent Services
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Run Keywords  Update Service Configuration On Consul  ${mechanism_path}  executor
-    ...                  AND  Restart Services  system
 
 *** Keywords ***
-Should Retrun Success=True For Existent Services And Success=False For Non-Existent Services
+Should Retrun 200 And ${property} For Existent Services And ${error_code} And ${property}=None For Non-Existent Services
     FOR  ${index}  IN RANGE  0  len(${content})
          Run Keyword If  "non-existent-service" in "${content}[${index}][serviceName]"  Run Keywords
-         ...             Should Be True  ${content}[${index}][statusCode]==500
-         ...             AND  Should Be Equal As Strings  ${content}[${index}][metrics][Success]  False
-         ...       ELSE  Run Keywords  Should Be True  ${content}[${index}][statusCode]==200
-         ...             AND  Should Be Equal As Strings  ${content}[${index}][metrics][Success]  True
-    END
-
-
-Should Retrun 200 And config For Existent Services And 404 And ${property}=None For Non-Existent Services
-    FOR  ${index}  IN RANGE  0  len(${content})
-         Run Keyword If  "non-existent-service" in "${content}[${index}][serviceName]"  Run Keywords
-         ...             Should Be True  ${content}[${index}][statusCode]==404
+         ...             Should Be True  ${content}[${index}][statusCode]==${error_code}
          ...             AND  Should Not Be True  ${content}[${index}][${property}]
          ...       ELSE  Run Keywords  Should Be True  ${content}[${index}][statusCode]==200
          ...             AND  Should Be True  ${content}[${index}][${property}]

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Positive.robot
@@ -3,6 +3,7 @@ Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
 Resource     TAF/testCaseModules/keywords/system-agent/systemAgentAPI.robot
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                        AND  Update MetricsMechanism To executor On Consul
 Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 
@@ -40,6 +41,6 @@ All Requested Services Should Return ${property}
     ${count}=  Evaluate  len(${content})
     FOR  ${index}  IN RANGE  0  ${count}
         List Should Contain Value  ${service_list}  ${content}[${index}][serviceName]
-        Run Keyword If  "${property}"=="metrics"  Should Be Equal As Strings  ${content}[${index}][metrics][Success]  True
+        Run Keyword If  "${property}"=="metrics"  Should Be True  ${content}[${index}][metrics]
         ...    ELSE IF  "${property}"=="config"  Should Be True  ${content}[${index}][config][config]
     END

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Negative.robot
@@ -5,6 +5,7 @@ Library      TAF/testCaseModules/keywords/setup/edgex.py
 Library      TAF/testCaseModules/keywords/setup/startup_checker.py
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                        AND  Update MetricsMechanism To executor On Consul
 Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Positive.robot
@@ -5,6 +5,7 @@ Library      TAF/testCaseModules/keywords/setup/edgex.py
 Library      TAF/testCaseModules/keywords/setup/startup_checker.py
 Suite Setup  Run Keywords  Setup Suite
 ...                        AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                        AND  Update MetricsMechanism To executor On Consul
 Suite Teardown  Run Teardown Keywords
 Force Tags      v2-api
 

--- a/TAF/utils/scripts/docker/restart-services.sh
+++ b/TAF/utils/scripts/docker/restart-services.sh
@@ -20,4 +20,10 @@ else
         --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --security-opt label:disable \
         --env CONF_DIR=${CONF_DIR} ${COMPOSE_IMAGE} \
         -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yaml" restart $*
+
+fi
+
+# Waiting for kong cache released
+if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
+  sleep 2
 fi


### PR DESCRIPTION
1. Remove success field validation in system tests
2. Waiting for 2s after restart services for kong cache issue.

Fix #461
Signed-off-by: Cherry Wang <cherry@iotechsys.com>