### PR TITLE
fix: add 'edgex-' prefix to app-service related containers

### DIFF
--- a/TAF/testCaseModules/keywords/setup/edgex.py
+++ b/TAF/testCaseModules/keywords/setup/edgex.py
@@ -100,7 +100,7 @@ def deploy_services(*args):
 
 def get_service_logs_since_timestamp(service, timestamp):
     SettingsInfo().TestLog.info("Get services {} logs".format(service))
-    logs = subprocess.check_output("docker logs {} --since {}".format(service, timestamp), shell=True)
+    logs = subprocess.check_output("docker logs edgex-{} --since {}".format(service, timestamp), shell=True)
     return logs
 
 

--- a/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
@@ -47,7 +47,7 @@ Setup Suite for App Service Secrets
     Setup Suite for App Service  http://${BASE_URL}:${APP_HTTP_EXPORT_PORT}
 
 Get AppService Token
-    ${command}=  Set Variable  docker exec ${app_service_name} cat /tmp/edgex/secrets/${app_service_name}/secrets-token.json
+    ${command}=  Set Variable  docker exec edgex-${app_service_name} cat /tmp/edgex/secrets/${app_service_name}/secrets-token.json
     ${result} =  Run Process  ${command}  shell=yes  output_encoding=UTF-8
     ${result_string}=  Evaluate  json.loads('''${result.stdout}''')  json
     Set Test Variable  ${token}  ${result_string}[auth][client_token]

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/GET-Negative.robot
@@ -21,7 +21,7 @@ ErrSysMgmtGET001 - Query metrics of the given services containing non-existent s
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrSysMgmtGET002 - Query config of the given services containing non-existent services
-    When Query Service Config  support-scheduler  non-existent-service-1  non-existent-service-2
+    When Query Service Config  support-notifications  non-existent-service-1  non-existent-service-2
     Then Should Return Status Code "207"
     And Should Retrun 200 And config For Existent Services And 404 And config=None For Non-Existent Services
     And Should Return Content-Type "application/json"

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Negative.robot
@@ -62,7 +62,7 @@ Should Retrun 200 For Existent Services And 404 For Unknown Services
     END
 
 Some Services Have Been Started/Stopped/Restarted
-    Found "${keyword}" in service "edgex-core-metadata" log
+    Found "${keyword}" in service "core-metadata" log
     Check Services Startup  data
     Check Services Stopped  core-command
 

--- a/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/system-agent/services/POST-Positive.robot
@@ -81,7 +81,7 @@ Services Have Been Restarted
     [Arguments]  ${keyword}  @{service_list}
     FOR  ${service}  IN  @{service_list}
         Run Keyword If  '${service}' == 'device-rest'  sleep  3s
-        ${service_log}=  Get service logs since timestamp  edgex-${service}  0
+        ${service_log}=  Get service logs since timestamp  ${service}  0
         Log  ${service_log}  # For error debug
         ${return_log}=  Get Lines Containing String  str(${service_log})  ${keyword}
         Should Not Be Empty  ${return_log}


### PR DESCRIPTION
- Add 'edgex-' prefix to app-service related containers.
- Change the test service for system-agent tests to avoid failure caused by previous tests.

Fix #480
Signed-off-by: Cherry Wang <cherry@iotechsys.com>