### PR TITLE
fix: increasing sleep time after start services for performance metrics

### DIFF
--- a/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
+++ b/TAF/testScenarios/performanceTest/performance-metrics-collection/2_service_startup_time/service_startup_time.robot
@@ -119,7 +119,7 @@ Start Services
   ...          --env WORK_DIR=${WORK_DIR}  --security-opt label:disable ${COMPOSE_IMAGE} \
   ...          -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yml" start
   Run Process  ${command}  shell=True
-  sleep  5s
+  sleep  8s
   ${result}=  Run Process  docker ps -a | grep Exited  shell=True
-  Should Not Be Equal As Integers  ${result.rc}  0  >>> Start Services Fail <<<
   Run Keyword If  ${result.rc} == 0  log  ${result.stdout}
+  Should Not Be Equal As Integers  ${result.rc}  0  >>> Start Services Fail <<<


### PR DESCRIPTION
Increasing sleep time after start services for performance metrics
Signed-off-by: Cherry Wang <cherry@iotechsys.com>