### PR TITLE
Set tag to skipped for aes related test

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot
@@ -58,6 +58,7 @@ TriggerPOST005 - Trigger pipeline (JSON-ZLIB)
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 TriggerPOST006 - Trigger pipeline (JSON-ZLIB-AES)
+    [Tags]  Skipped  # Since the key and initVector is deprecated. This case is invalid for non-security test.
     Given Set Functions FilterByDeviceName, Transform, Compress, Encrypt, SetResponseData
     And Set Transform Type json
     And Set Compress Algorithm zlib


### PR DESCRIPTION
After the change of [edgexfoundry/app-service-configurable PR#347](https://github.com/edgexfoundry/app-service-configurable/pull/347), [TriggerPost006](https://github.com/edgexfoundry/edgex-taf/blob/b20f26be9e550ed9362321b6c9b33ea464bdaf26/TAF/testScenarios/functionalTest/V2-API/app-service/trigger/POST-positive.robot#L60) is invalid for non-security test.

Signed-off-by: Cherry Wang <cherry@iotechsys.com>