### PR TITLE
fix(snap): update snap test scripts

### DIFF
--- a/TAF/utils/scripts/snap/api-gateway-token.sh
+++ b/TAF/utils/scripts/snap/api-gateway-token.sh
@@ -5,7 +5,7 @@ option=${1}
 USER="gateway"
 GROUP="gateway-group"
 
-logger "INFO:snap-TAF: api-gateway-token: $*"
+>&2 echo "INFO:snap-TAF: api-gateway-token: $*"
 
 # This script gets called at the beginning of each test suite. It's therefore the
 # best location to check if we should use a different app-service-configurable profile
@@ -20,19 +20,21 @@ if [ ! -z "$SNAP_APP_SERVICE_PORT" ]; then
 
   case ${SNAP_APP_SERVICE_PORT} in
     59704)
-      logger "INFO:snap-TAF: api-gateway-token: http-export"
-      snap set edgex-app-service-configurable profile=http-export > null
-      snap restart edgex-app-service-configurable > null
+      >&2 echo "INFO:snap-TAF: api-gateway-token: switching to http-export profile"
+      >&2 snap set edgex-app-service-configurable profile=http-export
+      >&2 snap restart edgex-app-service-configurable
     ;;
     59705)
-      logger "INFO:snap-TAF: api-gateway-token: functional-tests"
-      snap set edgex-app-service-configurable profile=functional-tests > null
-      snap restart edgex-app-service-configurable > null
+      >&2 echo "INFO:snap-TAF: api-gateway-token: switching to functional-tests profile"
+      >&2 snap set edgex-app-service-configurable profile=functional-tests
+      >&2 snap restart edgex-app-service-configurable
+
     ;;
     *)
-    logger "ERROR:snap-TAF: api-gateway-token: unsupported service on port  ${SNAP_APP_SERVICE_PORT}"
+    >&2 echo "ERROR:snap-TAF: api-gateway-token: unsupported service on port  ${SNAP_APP_SERVICE_PORT}"
     ;;
   esac
+  sleep 5
 fi
 
 # JWT File
@@ -66,6 +68,7 @@ case ${option} in
     exit 0
   ;;
 esac
+#>&2 edgex-cli deviceprofile list
 
-
+>&2 echo "INFO:snap-TAF: api-gateway-token done"
 

--- a/TAF/utils/scripts/snap/deploy-device-service.sh
+++ b/TAF/utils/scripts/snap/deploy-device-service.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 
-logger "INFO:snap-TAF: deploy-device-service"
+>&2 echo "INFO:snap-TAF: deploy-device-service"

--- a/TAF/utils/scripts/snap/deploy-edgex.sh
+++ b/TAF/utils/scripts/snap/deploy-edgex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-logger "INFO:snap-TAF: deploy-edgex.sh"
+>&2 echo "INFO:snap-TAF: deploy-edgex.sh"
 
 . "$SCRIPT_DIR/snap-utils.sh"
 

--- a/TAF/utils/scripts/snap/deploy-services.sh
+++ b/TAF/utils/scripts/snap/deploy-services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-logger "INFO:snap-TAF: deploy-services.sh $*"
+>&2 echo "INFO:snap-TAF: deploy-services.sh $*"
 
 . "$SCRIPT_DIR/snap-utils.sh"
 

--- a/TAF/utils/scripts/snap/restart-services.sh
+++ b/TAF/utils/scripts/snap/restart-services.sh
@@ -1,50 +1,50 @@
 #!/bin/sh
-logger "INFO:snap-TAF: restart-services.sh"
+>&2 echo "INFO:snap-TAF: restart-services.sh"
 
  
 
 for service in $@; do
     case $service in
      device-rest)
-        logger "INFO:snap-TAF: restart edgex-device-rest.device-rest"
+        >&2 echo "INFO:snap-TAF: restart edgex-device-rest.device-rest"
         sudo snap restart edgex-device-rest.device-rest
         ;;
       device-virtual)
-        logger "INFO:snap-TAF: restart edgexfoundry.device-virtual"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.device-virtual"
         sudo snap restart edgexfoundry.device-virtual
         ;;
-      app-service-*)
-        logger "INFO:snap-TAF: restart edgex-app-service-configurable.app-service-configurable"
+      app-*)
+        >&2 echo "INFO:snap-TAF: restart edgex-app-service-configurable.app-service-configurable"
         sudo snap restart edgex-app-service-configurable.app-service-configurable 
         ;; 
       system)
-        logger "INFO:snap-TAF: restart edgexfoundry.sys-mgmt-agent"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.sys-mgmt-agent"
         sudo snap restart edgexfoundry.sys-mgmt-agent
         ;;
       notifications)
-        logger "INFO:snap-TAF: restart edgexfoundry.support-notifications"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.support-notifications"
         sudo snap restart edgexfoundry.support-notifications
         ;;
      scheduler)
-        logger "INFO:snap-TAF: restart edgexfoundry.support-scheduler"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.support-scheduler"
         sudo snap restart edgexfoundry.support-scheduler
         ;;
       data)
-        logger "INFO:snap-TAF: restart edgexfoundry.core-data"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.core-data"
         sudo snap restart edgexfoundry.core-data
         ;;
       metadata)
-        logger "INFO:snap-TAF: restart edgexfoundry.core-metadata"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.core-metadata"
         sudo snap restart edgexfoundry.core-metadata
         ;;
       command)
-        logger "INFO:snap-TAF: restart edgexfoundry.core-command"
+        >&2 echo "INFO:snap-TAF: restart edgexfoundry.core-command"
         sudo snap restart edgexfoundry.core-command
         ;;
       *)    # unknown option
-        logger "ERROR:snap-TAF: restart unknown service $service"
+        >&2 echo "ERROR:snap-TAF: restart unknown service $service"
       ;;
     esac
+    sleep 2
   done     
-
-sleep 5
+  sleep 5

--- a/TAF/utils/scripts/snap/run-tests.sh
+++ b/TAF/utils/scripts/snap/run-tests.sh
@@ -7,8 +7,8 @@ help()
     printf --  "Usage:\n"
     printf --  "  run-tests.sh [OPTIONS]\n\n"
     printf --  "Available options:\n"
-    printf -- "  -s [filename] Test using specified local edgexfoundry snap [instead of --channel=2.0/stable]\n"
-    printf -- "  -a [filename] Test using specified local edgex-app-service-configurable snap [instead of --channel=2.0/stable]\n"
+    printf -- "  -s [filename] Test using specified local edgexfoundry snap [instead of --edge]\n"
+    printf -- "  -a [filename] Test using specified local edgex-app-service-configurable snap [instead of --edge]\n"
     printf -- "  -t [test]     Run V2 functional tests [all/app-service/core-command/core-data/core-metadata/support-notifications/support-scheduler/system-agent]\n"
     printf -- "  -d [test]     Run V2 device tests [all/device-virtual/device-modbus]\n"
     printf -- "  -n            Do not use security/API gateway\n"
@@ -93,7 +93,9 @@ snap_taf_enable_snap_testing
 snap_taf_deploy_edgex
 
 
- 
+ if [ $SECURITY_SERVICE_NEEDED = "false"]; then
+    sudo snap set edgexfoundry security-proxy=off
+ fi
 
 if [ ! -z "$V2_FUNCTIONAL_TESTS" ]; then
     echo "INFO:snap-TAF: running V2 API functional tests: $V2_FUNCTIONAL_TESTS ..." 

--- a/TAF/utils/scripts/snap/shutdown.sh
+++ b/TAF/utils/scripts/snap/shutdown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-logger "INFO:snap-TAF: shutdown.sh"
+>&2 echo "INFO:snap-TAF: shutdown.sh"
 
 
 . "$SCRIPT_DIR/snap-utils.sh"
@@ -7,5 +7,5 @@ logger "INFO:snap-TAF: shutdown.sh"
 snap_remove_all
 
 >&2 echo "INFO:snap: All EdgeX snaps removed"
-logger "INFO:snap-TAF: shutdown"
+>&2 echo "INFO:snap-TAF: shutdown"
 

--- a/TAF/utils/scripts/snap/stop-services.sh
+++ b/TAF/utils/scripts/snap/stop-services.sh
@@ -1,34 +1,34 @@
 #!/bin/sh
-logger "INFO:snap-TAF: stop-services.sh"
+>&2 echo "INFO:snap-TAF: stop-services.sh"
 
 for service in $@; do
     case $service in
       system)
-        logger "INFO:snap-TAF: stop edgexfoundry.sys-mgmt-agent"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.sys-mgmt-agent"
         sudo snap stop edgexfoundry.sys-mgmt-agent
         ;;
       notifications)
-        logger "INFO:snap-TAF: stop edgexfoundry.support-notifications"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.support-notifications"
         sudo snap stop edgexfoundry.support-notifications
         ;;
      scheduler)
-        logger "INFO:snap-TAF: stop edgexfoundry.support-scheduler"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.support-scheduler"
         sudo snap stop edgexfoundry.support-scheduler
         ;;
       data)
-        logger "INFO:snap-TAF: stop edgexfoundry.core-data"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.core-data"
         sudo snap stop edgexfoundry.core-data
         ;;
       metadata)
-        logger "INFO:snap-TAF: stop edgexfoundry.core-metadata"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.core-metadata"
         sudo snap stop edgexfoundry.core-metadata
         ;;
       command)
-        logger "INFO:snap-TAF: stop edgexfoundry.core-command"
+        >&2 echo "INFO:snap-TAF: stop edgexfoundry.core-command"
         sudo snap stop edgexfoundry.core-command
         ;;
     *)    # unknown option
-        logger "ERROR:snap-TAF: stop unknown service $service" 
+        >&2 echo "ERROR:snap-TAF: stop unknown service $service"
       ;;
     esac
   done     


### PR DESCRIPTION
This commits fixes a number of minor issues, so that more tests now pass when testing with snaps

- Changed logging to use stderr only instead of logger
- patched more docker-specific functionality in the robot and python files
- setting up correct modbus profiles
- using latest/edge instead of 2.0/edge
- installing the python3-is-python package

## Testing:
All the changes are snap-specific only. To run the tests with snaps do:

```
cd edgex-taf/TAF/utils/scripts/snap
sudo ./run-tests.sh -h # to print out help
sudo ./run-tests.sh -t all # to run all functional tests
sudo ./run-tests.sh -i  # to run integration tests
```

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>