### PR TITLE
fix(snap): fix issues with snaps and functional tests

### DIFF
--- a/TAF/utils/scripts/snap/restart-services.sh
+++ b/TAF/utils/scripts/snap/restart-services.sh
@@ -45,6 +45,6 @@ for service in $@; do
         >&2 echo "ERROR:snap-TAF: restart unknown service $service"
       ;;
     esac
-    sleep 2
+    sleep 1
   done     
-  sleep 5
+  sleep 1

--- a/TAF/utils/scripts/snap/run-tests.sh
+++ b/TAF/utils/scripts/snap/run-tests.sh
@@ -92,8 +92,11 @@ snap_taf_install_prerequisites
 snap_taf_enable_snap_testing
 snap_taf_deploy_edgex
 
+# Update Consul to prevent "Your IP is issuing too many concurrent connections, please rate limit your calls"
+sed -i -e 's@"disable@"limits": { "http_max_conns_per_client": 65536}, "disable@' /var/snap/edgexfoundry/current/consul/config/consul_default.json 
+snap restart edgexfoundry.security-proxy-setup
 
- if [ $SECURITY_SERVICE_NEEDED = "false"]; then
+ if [ $SECURITY_SERVICE_NEEDED = "false" ]; then
     sudo snap set edgexfoundry security-proxy=off
  fi
 

--- a/TAF/utils/scripts/snap/snap-taf-tests.sh
+++ b/TAF/utils/scripts/snap/snap-taf-tests.sh
@@ -53,7 +53,7 @@ snap_taf_enable_snap_testing()
     # in case python2 is the default, replace it with python3 (can also be done by apt-get install python3-is-python)
     sed -s -i -e 's@Start process  python @Start process  python3 @' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/*.robot
 
-    # remove system-agent tests - we don't run them
+    # remove system-agent tests - we don't run them because the system agent service has been deprecated since the Ireland release (2.0)
     rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/info
     rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/services
 

--- a/TAF/utils/scripts/snap/snap-taf-tests.sh
+++ b/TAF/utils/scripts/snap/snap-taf-tests.sh
@@ -43,12 +43,22 @@ snap_taf_enable_snap_testing()
     # update host name
     sed -i -e 's@Host=edgex-support-scheduler@Host=localhost@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/POST-Positive.robot
 
+    # this test assumes we are running on two different IP addresses. Set DOCKER_IP to an invalid IP in this case as otherwise we get duplicate transmissions
+    sed -i -e 's@${DOCKER_HOST_IP}@"invalid-ip"@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/GET-Positive.robot
 
    # integration tests
    # The notification sender is "core-metadata", not "edgex-core-metadata"
     sed -i -e 's@edgex-core-metadata@core-metadata@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_metadata_notifications/metadata_notifications.robot
 
-    export DOCKER_HOST_IP="127.0.0.1"
+    # in case python2 is the default, replace it with python3 (can also be done by apt-get install python3-is-python)
+    sed -s -i -e 's@Start process  python @Start process  python3 @' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/*.robot
+
+    # remove system-agent tests - we don't run them
+    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/info
+    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/services
+
+    
+    export DOCKER_HOST_IP="localhost"
 
 }
 


### PR DESCRIPTION
This commit fixes the remaining issues that prevent
support-notifications and support-scheduler tests from
passing when testing with snaps.

It also disables the system-agent tests.

Running all tests with
```
cd TAF/utils/scrips/snap
sudo ./run-tests.sh -t all
```
now results in all tests passing.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>