### PR TITLE
feat(snap): enable integration tests with snaps

### DIFF
--- a/TAF/utils/scripts/snap/api-gateway-token.sh
+++ b/TAF/utils/scripts/snap/api-gateway-token.sh
@@ -5,38 +5,10 @@ option=${1}
 USER="gateway"
 GROUP="gateway-group"
 
->&2 echo "INFO:snap-TAF: api-gateway-token: $*"
+. "$SCRIPT_DIR/snap-utils.sh"
 
-# This script gets called at the beginning of each test suite. It's therefore the
-# best location to check if we should use a different app-service-configurable profile
-# note that this depends on a change to AppServiceAPI.robot:
-#   Check app-service is available
-#    ${port}=  Split String  ${url}  :
-#    Set Environment Variable  SNAP_APP_SERVICE_PORT  ${port}[2]
-#    Check service is available  ${port}[2]   /api/v2/ping
-
-# also - this script should not write anything but the token to stdout
-if [ ! -z "$SNAP_APP_SERVICE_PORT" ]; then
-
-  case ${SNAP_APP_SERVICE_PORT} in
-    59704)
-      >&2 echo "INFO:snap-TAF: api-gateway-token: switching to http-export profile"
-      >&2 snap set edgex-app-service-configurable profile=http-export
-      >&2 snap restart edgex-app-service-configurable
-    ;;
-    59705)
-      >&2 echo "INFO:snap-TAF: api-gateway-token: switching to functional-tests profile"
-      >&2 snap set edgex-app-service-configurable profile=functional-tests
-      >&2 snap restart edgex-app-service-configurable
-
-    ;;
-    *)
-    >&2 echo "ERROR:snap-TAF: api-gateway-token: unsupported service on port  ${SNAP_APP_SERVICE_PORT}"
-    ;;
-  esac
-  sleep 5
-fi
-
+snap_maybe_switch_asc_profile
+ 
 # JWT File
 JWT_FILE=/var/snap/edgexfoundry/current/secrets/security-proxy-setup/kong-admin-jwt
 JWT_VOLUME=/var/snap/edgexfoundry/current/secrets/security-proxy-setup
@@ -68,7 +40,7 @@ case ${option} in
     exit 0
   ;;
 esac
-#>&2 edgex-cli deviceprofile list
+
 
 >&2 echo "INFO:snap-TAF: api-gateway-token done"
 

--- a/TAF/utils/scripts/snap/restart-services.sh
+++ b/TAF/utils/scripts/snap/restart-services.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 >&2 echo "INFO:snap-TAF: restart-services.sh"
 
- 
 
 for service in $@; do
     case $service in
@@ -12,6 +11,10 @@ for service in $@; do
       device-virtual)
         >&2 echo "INFO:snap-TAF: restart edgexfoundry.device-virtual"
         sudo snap restart edgexfoundry.device-virtual
+        ;;
+      mqtt-broker)
+        >&2 echo "INFO:snap-TAF: restart mosquitto"
+        sudo snap restart mosquitto
         ;;
       app-*)
         >&2 echo "INFO:snap-TAF: restart edgex-app-service-configurable.app-service-configurable"
@@ -43,6 +46,7 @@ for service in $@; do
         ;;
       *)    # unknown option
         >&2 echo "ERROR:snap-TAF: restart unknown service $service"
+        logger "ERROR:snap-TAF: restart unknown service $service"
       ;;
     esac
     sleep 1

--- a/TAF/utils/scripts/snap/snap-taf-tests.sh
+++ b/TAF/utils/scripts/snap/snap-taf-tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+source "$SCRIPT_DIR/snap-utils.sh"
 
 snap_taf_install_prerequisites()
 {
@@ -18,47 +19,75 @@ snap_taf_install_prerequisites()
 
 } 
  
-snap_taf_enable_snap_testing() 
+snap_taf_patch_files()
 {
+    # TODO: Some of these changes should be submitted as Pull Requests to update the tests. 
 
-    # modify `TAF/config/global_variables.py`
+    # 1: with snaps, everything is running on localhost. The Docker host names therefore need to be replaced
+    sed -i -e 's@Host=edgex-support-scheduler@Host=localhost@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/POST-Positive.robot
+    sed -i -e 's@edgex-core-data@localhost@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_data_clean_up/clean_up_events_and_readings.robot
+    sed -i -e 's@edgex-core-command@localhost@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_kuiper/export_by_kuiper_rules.robot
+
+    # 2: Some of the integration tests don't specify which app-configurable profile is being used. They assume we are running with docker and 
+    #    that all profiles are running. That can be fixed by changing the suite setup to include the profile name
+
+     # For that to work we also need to modify APPServiceAPI.robot to set the app service port
+    sed -i -e ':a;N;$!ba;s@:\n    Check@:\n    Set Environment Variable  SNAP_APP_SERVICE_PORT  ${port}[2]\n    Check@' $WORK_DIR/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
+
+    sed -i -e ':a;N;$!ba;s@Setup Suite\n@Setup Suite for App Service  http://${BASE_URL}:${APP_EXTERNAL_MQTT_TRIGGER_PORT}\n@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_app_service_configurable/external_mqtt_trigger.robot
+    sed -i -e ':a;N;$!ba;s@Setup Suite\n@Setup Suite for App Service  http://${BASE_URL}:${APP_HTTP_EXPORT_PORT}\n@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
+    sed -i -e ':a;N;$!ba;s@Setup Suite\n@Setup Suite for App Service  http://${BASE_URL}:${APP_HTTP_EXPORT_PORT}\n@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_end_to_end/export_store_forward.robot
+
+    sed -i -e ':a;N;$!ba;s@Suite Setup  Run Keywords  Setup Suite\n@Resource         TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot\nSuite Setup  Run Keywords  Setup Suite for App Service  http://${BASE_URL}:${APP_MQTT_EXPORT_PORT}\n@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_mqtt_message_bus/device_virtual_config.robot
+    sed -i -e ':a;N;$!ba;s@Suite Setup  Run Keywords  Setup Suite\n@Resource         TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot\nSuite Setup  Run Keywords  Setup Suite for App Service  http://${BASE_URL}:${APP_MQTT_EXPORT_PORT}\n@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_mqtt_message_bus/core_data_config.robot
+      
+    # 3: Change the config from "docker" to "snap"
     sed -i -e 's@"docker"@"snap"@' $WORK_DIR/TAF/config/global_variables.py
 
-    # modify commonKeywords.robot
+    # 4: for the tokens - change docker-specific commands and path names to snap-specific ones
     sed -i -e 's@docker exec edgex-core-consul cat /tmp/edgex/secrets/@cat /var/snap/edgexfoundry/current/secrets/@' $WORK_DIR/TAF/testCaseModules/keywords/common/commonKeywords.robot
-
-    # modify POST.robot
     sed -i -e 's@docker exec edgex-${app_service_name} cat /tmp/edgex/secrets@cat /var/snap/edgex-app-service-configurable/current@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/app-service/secrets/POST.robot
 
-    # modify APPServiceAPI.robot
-    sed -i -e ':a;N;$!ba;s@:\n    Check@:\n    Set Environment Variable  SNAP_APP_SERVICE_PORT  ${port}[2]\n    Check@' $WORK_DIR/TAF/testCaseModules/keywords/app-service/AppServiceAPI.robot
-   
+    sed -i -e 's@/tmp/edgex/secrets@/var/snap/edgexfoundry/current/secrets@' $WORK_DIR/TAF/utils/src/setup/redis-subscriber.py
 
-    # modify TAF/testCaseModules/keywords/setup/edgex.py 
-    sed -i -e "s!\"docker logs edgex-{} --since {}\".format(service, timestamp)!\"journalctl -g {} -S @{}\".format(service.replace(\'app-\',\'\'),timestamp)!" $WORK_DIR/TAF/testCaseModules/keywords/setup/edgex.py
-   
-   # modify TAF/testCaseModules/keywords/setup/startup_checker.py 
+    # 5: logging is done using journalctl
+    sed -i -e "s!\"docker logs edgex-{} --since {}\"!\"journalctl -q -g {} -S @{} || true\"!" $WORK_DIR/TAF/testCaseModules/keywords/setup/edgex.py 
     sed -i -e 's!"docker logs {}"!"journalctl -g {}"!' $WORK_DIR/TAF/testCaseModules/keywords/setup/startup_checker.py
 
-    # update host name
-    sed -i -e 's@Host=edgex-support-scheduler@Host=localhost@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-scheduler/intervalaction/POST-Positive.robot
+    # 6. Other issues:
+    # in case python2 is the default, replace it with python3 (can also be done by apt-get install python3-is-python)
+    sed -s -i -e 's@Start process  python @Start process  python3 @' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/*.robot
+
+    #  remove system-agent tests - we don't run them because the system agent service has been deprecated since the Ireland release (2.0)
+    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/info
+    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/services
+
+    #  The notification sender is "core-metadata", not "edgex-core-metadata"
+    sed -i -e 's@edgex-core-metadata@core-metadata@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_metadata_notifications/metadata_notifications.robot
 
     # this test assumes we are running on two different IP addresses. Set DOCKER_IP to an invalid IP in this case as otherwise we get duplicate transmissions
     sed -i -e 's@${DOCKER_HOST_IP}@"invalid-ip"@' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/GET-Positive.robot
 
-   # integration tests
-   # The notification sender is "core-metadata", not "edgex-core-metadata"
-    sed -i -e 's@edgex-core-metadata@core-metadata@' $WORK_DIR/TAF/testScenarios/integrationTest/UC_metadata_notifications/metadata_notifications.robot
 
-    # in case python2 is the default, replace it with python3 (can also be done by apt-get install python3-is-python)
-    sed -s -i -e 's@Start process  python @Start process  python3 @' $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/support-notifications/transmission/*.robot
-
-    # remove system-agent tests - we don't run them because the system agent service has been deprecated since the Ireland release (2.0)
-    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/info
-    rm -rf $WORK_DIR/TAF/testScenarios/functionalTest/V2-API/system-agent/services
-
+    # 7. changes having to do with mosquitto
     
-    export DOCKER_HOST_IP="localhost"
+    # edgex-mqtt-broker is mosquitto, as per https://github.com/edgexfoundry/developer-scripts/blob/5af601bb1938c1ad76d6b3e7e113bdfc088f9f48/compose-builder/add-mqtt-broker.yml
+    sed -i -e 's@edgex-mqtt-broker@localhost@' $WORK_DIR/TAF/testData/kuiper/action.json
+
+    sed -i -e "s!docker logs edgex-mqtt-broker --since ${log_timestamp}!journalctl -q -u snap.mosquitto.mosquitto.service -S \@${log_timestamp}!" $WORK_DIR/TAF/testScenarios/integrationTest/UC_mqtt_message_bus/core_data_config.robot
+    sed -i -e "s!docker logs edgex-mqtt-broker --since ${timestamp}!journalctl -q -u snap.mosquitto.mosquitto.service -S \@${timestamp}!" $WORK_DIR/TAF/testScenarios/integrationTest/UC_mqtt_message_bus/device_virtual_config.robot
+ 
+}
+
+
+
+
+snap_taf_enable_snap_testing()
+{
+   snap_taf_patch_files
+     
+   # set this for the tests that need it
+   export DOCKER_HOST_IP="localhost"
 
 }
 
@@ -73,7 +102,10 @@ snap_taf_deploy_edgex()
 
 snap_taf_run_functional_tests() # arg:  tests to run
 {
-   cd ${WORK_DIR}
+    # required by the functional tests, but not by integration tests
+    snap_install_device_camera
+   
+    cd ${WORK_DIR}
 
     # 2. Run V2 API Functional testing (using directories in TAF/testScenarios/functionalTest/V2-API )
     # 
@@ -109,12 +141,18 @@ snap_taf_run_functional_device_tests()
 
 snap_taf_run_integration_tests()
 {
-    rm -f $WORK_DIR/TAF/testArtifacts/reports/cp-edgex/integration-test.html 
- 
+    local INCLUDE_TESTS=$1
+    local LOG_TARGET=$2
+    rm -f $WORK_DIR/TAF/testArtifacts/reports/cp-edgex/$LOG_TARGET 
+
+   
     cd ${WORK_DIR}
-    python3 -m TUC --exclude Skipped -u integrationTest -p device-virtual
-    cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/integration-test.html 
-     >&2 echo "INFO:snap: V2 API Device Test report copied to ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/integration-test.html"
+    python3 -m TUC --exclude Skipped --include $INCLUDE_TESTS -u integrationTest -p device-virtual
+    cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/$LOG_TARGET
+
+    >&2 echo "INFO:snap: V2 API Device Test report copied to ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/"
+
+  
  }
 
 snap_taf_shutdown()

--- a/TAF/utils/scripts/snap/snap-utils.sh
+++ b/TAF/utils/scripts/snap/snap-utils.sh
@@ -23,14 +23,14 @@ snap_install()
 
 snap_remove_all()
 { 
+    snap remove --purge edgex-app-service-configurable
     snap remove --purge edgex-device-mqtt
     snap remove --purge edgex-device-modbus
     snap remove --purge edgex-device-camera
     snap remove --purge edgex-device-rest
-    snap remove --purge edgex-app-service-configurable
     snap remove --purge edgexfoundry
     snap remove --purge mosquitto
-}
+ }
 
 snap_install_edgexfoundry()
 {
@@ -49,6 +49,103 @@ snap_install_edgexfoundry()
 
 
 }
+
+snap_start_asc()
+{
+    >&2 snap start edgex-app-service-configurable
+}
+
+snap_stop_asc()
+{
+    >&2 echo "INFO:snap-TAF: stopping app-service-configurable"
+    >&2 snap stop edgex-app-service-configurable
+}
+
+snap_set_asc_profile()
+{
+    local PROFILE=$1
+    >&2 echo "INFO:snap-TAF: snap_set_asc_profile: switching to $PROFILE profile"
+    >&2 snap set edgex-app-service-configurable profile=$PROFILE
+    >&2 snap restart edgex-app-service-configurable
+}
+
+snap_taf_update_consul()
+{
+    # Update Consul to prevent "Your IP is issuing too many concurrent connections, please rate limit your calls"
+    sed -i -e 's@"disable@"limits": { "http_max_conns_per_client": 65536}, "disable@' /var/snap/edgexfoundry/current/consul/config/consul_default.json 
+    snap restart edgexfoundry.security-proxy-setup
+}
+
+snap_set_messagebus_to_mqtt()
+{
+    # note that the integration tests use mqtt as the bus https://github.com/edgexfoundry/edgex-compose/blob/main/taf/docker-compose-taf-mqtt-bus.yml
+    #      
+    # rules-engine
+ #   snap set edgexfoundry env.app-service-configurable.trigger.edgex-message-bus.publish-host.port="1883"
+ #   snap set edgexfoundry env.app-service-configurable.trigger.edgex-message-bus.publish-host.protocol="tcp" 
+ #   snap set edgexfoundry env.app-service-configurable.trigger.edgex-message-bus.subscribe-host.port="1883"
+ #   snap set edgexfoundry env.app-service-configurable.trigger.edgex-message-bus.subscribe-host.protocol="tcp" 
+  #snap set edgexfoundry env.app-service-configurable.trigger.edgex-message-bus.type="mqtt" 
+
+    # rule engine
+    ASC_FILE=/var/snap/edgexfoundry/current/config/app-service-configurable/res/app-service-configurable.env
+    echo "export TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_PORT=1883"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_PROTOCOL=tcp"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_PORT=1883"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_PROTOCOL=tcp"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_TYPE=mqtt"  | tee -a $ASC_FILE > /dev/null    
+    >&2 snap restart edgexfoundry.app-service-configurable
+
+    #core-data
+#    snap set edgexfoundry env.core-data.messagequeue.optional.clientid="core-data"
+    >&2 snap set edgexfoundry env.core-data.messagequeue.host="localhost" # edgex-mqtt-broker
+    >&2 snap set edgexfoundry env.core-data.messagequeue.port="1883"
+    >&2 snap set edgexfoundry env.core-data.messagequeue.protocol="tcp"
+    >&2 snap set edgexfoundry env.core-data.messagequeue.type="mqtt"
+    >&2 snap restart edgexfoundry.core-data 
+
+   #device-virtual
+    >&2 snap set edgexfoundry env.device-virtual.messagequeue.host="localhost" # edgex-mqtt-broker
+    >&2 snap set edgexfoundry env.device-virtual.messagequeue.port="1883"
+    >&2 snap set edgexfoundry env.device-virtual.messagequeue.protocol="tcp"
+    >&2 snap set edgexfoundry env.device-virtual.messagequeue.type="mqtt"
+    >&2 snap restart edgexfoundry.device-virtual 
+
+ 
+    # asc (mqtt export/http export/external-mqtt-trigger)
+    ASC_FILE=/var/snap/edgex-app-service-configurable/current/config/res/app-service-configurable.env
+    echo "export TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_PORT=1883"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_PROTOCOL=tcp"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_PORT=1883"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_PROTOCOL=tcp"  |  tee -a $ASC_FILE > /dev/null
+    echo "export TRIGGER_EDGEXMESSAGEBUS_TYPE=mqtt"  | tee -a $ASC_FILE > /dev/null    
+    >&2 snap restart edgex-app-service-configurable
+
+    >&2 sudo snap restart mosquitto
+  
+
+    
+     >&2 echo "INFO:snap-TAF: Switched to using MQTT Message Bus"
+     
+}
+
+
+snap_update_profiles()
+{
+    # The docker compose scripts in https://github.com/edgexfoundry/edgex-compose/blob/2a75ddbc5474e079106d3bac7fcb726271b75f59/taf/docker-compose-taf.yml
+    # set up the app service configurable services, including http_export exporting to port 7770
+ # besides using the compose files, see also the get-compose-file.sh script in TAF
+
+    sed -i -e 's@https://f095cfcd-a3f6-4885-85ea-7157c6afd17e.mock.pstmn.io@http://localhost:7770@' /var/snap/edgex-app-service-configurable/current/config/res/http-export/configuration.toml 
+    sed -i -e 's@Topic = \"edgex-export\"@Topic = \"edgex-events\"@' /var/snap/edgex-app-service-configurable/current/config/res/mqtt-export/configuration.toml 
+    
+    sed -i -e 's@LogLevel = \"INFO\"@LogLevel = \"DEBUG\"@' /var/snap/edgex-app-service-configurable/current/config/res/http-export/configuration.toml 
+    sed -i -e 's@LogLevel = \"INFO\"@LogLevel = \"DEBUG\"@' /var/snap/edgex-app-service-configurable/current/config/res/mqtt-export/configuration.toml 
+   sed -i -e 's@LogLevel = \"INFO\"@LogLevel = \"DEBUG\"@' /var/snap/edgex-app-service-configurable/current/config/res/external-mqtt-trigger/configuration.toml 
+
+
+}
+
 
 snap_install_asc() 
 {
@@ -78,6 +175,9 @@ snap_install_asc()
        exit 1
     fi 
 
+    # replicate the work done in Docker compose files, modifying the profiles
+    snap_update_profiles
+
     snap set edgex-app-service-configurable profile=$PROFILE
     snap start edgex-app-service-configurable
 }
@@ -91,10 +191,20 @@ snap_start_device_rest()
     snap start edgex-device-rest.device-rest
 }
 
+snap_install_device_camera()
+{
+    snap install edgex-device-camera --channel=latest/edge
+    # this is required if we are not using a edgexfoundry snap from the snap store
+    snap connect edgexfoundry:edgex-secretstore-token edgex-device-camera:edgex-secretstore-token
+    snap start edgex-device-camera.device-camera
+    
+}
+
+
 snap_start_device_virtual()
 {
-    rm /var/snap/edgexfoundry/current/config/device-virtual/res/devices/*
-    rm /var/snap/edgexfoundry/current/config/device-virtual/res/profiles/*
+    rm -f /var/snap/edgexfoundry/current/config/device-virtual/res/devices/*
+    rm -f  /var/snap/edgexfoundry/current/config/device-virtual/res/profiles/*
     cp ${WORK_DIR}/TAF/config/device-virtual/sample_profile.yaml /var/snap/edgexfoundry/current/config/device-virtual/res/profiles/
     snap start edgexfoundry.device-virtual
     
@@ -111,24 +221,121 @@ snap_start_kuiper()
     snap start edgexfoundry.kuiper
 }
 
+snap_start_edgexfoundry_rules_engine()
+{
+    snap start edgexfoundry.app-service-configurable
+}
+
 snap_install_device_modbus()
 {
     snap install edgex-device-modbus --channel=latest/edge
-    rm /var/snap/edgex-device-modbus/current/config/device-modbus/res/devices/*
-    rm /var/snap/edgex-device-modbus/current/config/device-modbus/res/profiles/*
+    rm -f /var/snap/edgex-device-modbus/current/config/device-modbus/res/devices/*
+    rm -f /var/snap/edgex-device-modbus/current/config/device-modbus/res/profiles/*
     snap connect edgexfoundry:edgex-secretstore-token edgex-device-modbus:edgex-secretstore-token
     cp ${WORK_DIR}/TAF/config/device-modbus/sample_profile.yaml /var/snap/edgex-device-modbus/current/config/device-modbus/res/profiles/
     snap start edgex-device-modbus.device-modbus
 }
  
+snap_taf_patch_mosquitto()
+{
+    # the qOS tests require verbose mosquitto output
+    echo "log_type all" | sudo tee -a /var/snap/mosquitto/common/mosquitto.conf > /dev/null
+    snap restart mosquitto
+}
+
+
+
 snap_install_all()
 {
+    kill_python_processes
     snap install mosquitto
+    snap_taf_patch_mosquitto
     snap_install_edgexfoundry
     snap_start_support_services
     snap_start_device_virtual
+    snap_start_edgexfoundry_rules_engine
     snap_start_device_rest
     snap_start_kuiper
     snap_install_device_modbus
+
     snap_install_asc functional-tests
+}
+
+kill_python_process()
+{
+    local the_process=$1
+
+    if pgrep -f $the_process > /dev/null
+    then
+        >&2 echo "INFO:snap-TAF: killing python $the_process process"
+        >&2 kill $(pgrep -f $the_process)
+    fi
+}
+
+# the python httpd_server.py process is sometimes left hanging which causes the next run to fail
+kill_python_processes()
+{
+    kill_python_process "httpd_server.py"
+    kill_python_process "mqtt-publisher.py"
+    kill_python_process "mqtt-subscriber.py"
+    kill_python_process "redis-subscriber.py"
+}
+
+snap_get_asc_profile_from_port()
+{
+    case ${SNAP_APP_SERVICE_PORT} in
+        59703)
+        SNAP_APP_SERVICE_PROFILE="mqtt-export"
+        ;;
+        59704)
+        SNAP_APP_SERVICE_PROFILE="http-export"
+        ;;
+        59705)
+        SNAP_APP_SERVICE_PROFILE="functional-tests"
+        ;;
+        59706)
+        SNAP_APP_SERVICE_PROFILE="external-mqtt-trigger"
+        ;;
+        *)
+        >&2 echo "ERROR:snap-TAF: api-gateway-token: unsupported service on port  ${SNAP_APP_SERVICE_PORT}"
+        SNAP_APP_SERVICE_PROFILE=""
+        ;;
+    esac 
+}
+
+
+snap_maybe_switch_asc_profile()
+{
+  
+  
+    # This script gets called at the beginning of each test suite. It's therefore the
+    # best location to check if we should use a different app-service-configurable profile
+    # note that this depends on a change to AppServiceAPI.robot:
+    #   Check app-service is available
+    #    ${port}=  Split String  ${url}  :
+    #    Set Environment Variable  SNAP_APP_SERVICE_PORT  ${port}[2]
+    #    Check service is available  ${port}[2]   /api/v2/ping
+
+    # also - this script should not write anything but the token to stdout
+    if [ ! -z "$SNAP_APP_SERVICE_PORT" ]; then
+ 
+        snap_get_asc_profile_from_port
+
+        CURRENTPROFILE=`snap get edgex-app-service-configurable profile`
+        if [ "$CURRENTPROFILE" != "$SNAP_APP_SERVICE_PROFILE" ]; then
+             >&2 echo "INFO:snap-TAF: switching to ASC profile $SNAP_APP_SERVICE_PROFILE ($SNAP_APP_SERVICE_PORT)"
+              snap_set_asc_profile $SNAP_APP_SERVICE_PROFILE
+            sleep 5
+        else
+            >&2 echo "INFO:snap-TAF: ASC profile unchanged  $SNAP_APP_SERVICE_PROFILE ($SNAP_APP_SERVICE_PORT)"
+        fi
+        SNAP_APP_SERVICE_PORT=""
+
+        # in case it was stopped
+        snap_start_asc
+    else
+        >&2 echo "INFO:snap-TAF: api-snap_maybe_switch_asc_profile-token: no ASC profile has been specified. Stopping App-service-configurable"
+        snap_stop_asc
+    fi
+
 }

--- a/TAF/utils/scripts/snap/stop-services.sh
+++ b/TAF/utils/scripts/snap/stop-services.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 >&2 echo "INFO:snap-TAF: stop-services.sh"
+logger "INFO:snap-TAF: stop-services.sh $@"
+ 
 
 for service in $@; do
     case $service in
@@ -7,6 +9,11 @@ for service in $@; do
         >&2 echo "INFO:snap-TAF: stop edgexfoundry.sys-mgmt-agent"
         sudo snap stop edgexfoundry.sys-mgmt-agent
         ;;
+      mqtt-broker)
+        >&2 echo "INFO:snap-TAF: stop mosquitto"
+        sudo snap stop mosquitto
+        ;;
+      
       notifications)
         >&2 echo "INFO:snap-TAF: stop edgexfoundry.support-notifications"
         sudo snap stop edgexfoundry.support-notifications
@@ -27,7 +34,21 @@ for service in $@; do
         >&2 echo "INFO:snap-TAF: stop edgexfoundry.core-command"
         sudo snap stop edgexfoundry.core-command
         ;;
-    *)    # unknown option
+      app-*)
+        >&2 echo "INFO:snap-TAF: stop edgex-app-service-configurable($service)"
+        sudo snap stop edgex-app-service-configurable
+        ;;
+      edgex-scalability-test-mqtt-export)
+        >&2 echo "INFO:snap-TAF: stop  edgex-scalability-test-mqtt-export"
+        snap set edgex-app-service-configurable profile=mqtt-export
+        snap restart edgex-app-service-configurable
+        ;;
+      scalability-test-mqtt-export)
+        >&2 echo "INFO:snap-TAF: stop  scalability-test-mqtt-export"
+        snap set edgex-app-service-configurable profile=mqtt-export
+        snap restart edgex-app-service-configurable
+        ;;
+      *)    # unknown option
         >&2 echo "ERROR:snap-TAF: stop unknown service $service"
       ;;
     esac


### PR DESCRIPTION
This commit updates the scripts for running TAF tests
with snaps, fixing a number of issues with running the
integration tests.

With this PR, all TAF integration tests should pass when using snaps.
Test using:

```
cd edgex-taf/TAF/utils/scripts/snap
sudo ./run-tests -i
```


Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>