### PR TITLE
fix: Update script to pull the v2.1.x images

### DIFF
--- a/TAF/utils/scripts/docker/exec_performance_metrics.sh
+++ b/TAF/utils/scripts/docker/exec_performance_metrics.sh
@@ -2,7 +2,7 @@
 # set default values
 USE_ARCH=${1:-x86_64}
 USE_SECURITY=${2:--}
-USE_SHA1=${3:-master}
+USE_SHA1=${3:-jakarta}
 
 # # x86_64 or arm64
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64"

--- a/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
+++ b/TAF/utils/scripts/docker/get-compose-file-perfermance.sh
@@ -2,7 +2,7 @@
 # # set default values
 USE_ARCH=${1:-x86_64}
 USE_SECURITY=${2:--}
-USE_SHA1=${3:-master}
+USE_SHA1=${3:-jakarta}
 
 # # x86_64 or arm64
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64"

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -3,7 +3,7 @@
 # # set default values
 USE_ARCH=${1:--x86_64}
 USE_SECURITY=${2:--}
-USE_SHA1=${3:-main}
+USE_SHA1=${3:-jakarta}
 TEST_STRATEGY=${4:-}
 
 # # x86_64 or arm64

--- a/TAF/utils/scripts/docker/run-tests.sh
+++ b/TAF/utils/scripts/docker/run-tests.sh
@@ -2,8 +2,8 @@
 # Arguments and the default values
 USE_ARCH=${1:-x86_64}
 SECURITY_SERVICE_NEEDED=${2:-false}
-TEST_STRATEGY=${3:-1}  # 1: functional-test, 2: integration-test
-TEST_SERVICE=${4:-all}
+TEST_STRATEGY=${3:-functional-test}
+TEST_SERVICE=${4:-v2-api}
 DEPLOY_SERVICES=${5:-} # no-deployment or empty
 
 
@@ -11,9 +11,7 @@ DEPLOY_SERVICES=${5:-} # no-deployment or empty
 [ "$USE_ARCH" = "arm64" ] && USE_ARM64="-arm64"
 
 # Common Variables
-USE_DB=-redis
-USE_RELEASE=pre-release
-USE_SHA1=master  # edgex-compose branch or SHA1
+USE_SHA1=jakarta  # edgex-compose branch or SHA1
 TAF_COMMON_IMAGE=nexus3.edgexfoundry.org:10003/edgex-taf-common${USE_ARM64}:latest
 COMPOSE_IMAGE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose${USE_ARM64}:latest
 
@@ -25,22 +23,28 @@ fi
 
 if [ "$DEPLOY_SERVICES" != "no-deployment" ]; then
   # Get compose file from edgex-compose
-  sh get-compose-file.sh ${USE_DB} ${USE_ARCH} ${USE_SECURITY} ${USE_RELEASE} ${USE_SHA1}
+  sh get-compose-file.sh ${USE_ARCH} ${USE_SECURITY} ${USE_SHA1} ${TEST_STRATEGY}
 
   # Create backup report directory
   mkdir -p ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex
+
+  if [ "$TEST_STRATEGY" = "integration-test" ] && [ "$TEST_SERVICE" = "mqtt" ]; then
+	      RUN_TAG=mqtt-bus
+  else
+	      RUN_TAG=deploy-base-service
+  fi
 
   # Install base service
   docker run --rm --network host -v ${WORK_DIR}:${WORK_DIR}:z -w ${WORK_DIR} \
           -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
           -e USE_DB=${USE_DB} --security-opt label:disable \
           -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
-          --exclude Skipped --include deploy-base-service -u deploy.robot -p default
+          --exclude Skipped --include ${RUN_TAG} -u deploy.robot -p default
   cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/deploy-base.html
 fi
 
 case ${TEST_STRATEGY} in
-  1)
+  functional-test)
     # Run functional test
     case ${TEST_SERVICE} in
       device-virtual)
@@ -59,10 +63,11 @@ case ${TEST_STRATEGY} in
               --exclude Skipped -u functionalTest/device-service -p device-modbus
         cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/modbus.html
       ;;
-      all)
+      v2-api)
         docker run --rm --network host -v ${WORK_DIR}:${WORK_DIR}:z -w ${WORK_DIR} \
                 --security-opt label:disable -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
                 -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
+                --env-file ${WORK_DIR}/TAF/utils/scripts/docker/common-taf.env \
                 -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
                 --exclude Skipped --include v2-api -u functionalTest/V2-API -p default
         cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/v2-api-test.html
@@ -71,21 +76,22 @@ case ${TEST_STRATEGY} in
         docker run --rm --network host -v ${WORK_DIR}:${WORK_DIR}:z -w ${WORK_DIR} \
                 --security-opt label:disable -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
                 -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
+                --env-file ${WORK_DIR}/TAF/utils/scripts/docker/common-taf.env \
                 -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
                 --exclude Skipped --include v2-api -u functionalTest/V2-API/${TEST_SERVICE} -p default
         cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/${TEST_SERVICE}-test.html
       ;;
     esac
   ;;
-  2)
+  integration-test)
     # Run integration test
     ## Only support deploying edgex services through docker-compose file.
-
     docker run --rm --network host -v ${WORK_DIR}:${WORK_DIR}:z -w ${WORK_DIR} \
             --security-opt label:disable -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+            --env-file ${WORK_DIR}/TAF/utils/scripts/docker/common-taf.env \
             -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
             -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
-            --exclude Skipped -u integrationTest -p device-virtual
+            --exclude Skipped --include MessageQueue=${TEST_SERVICE} -u integrationTest -p device-virtual
     cp ${WORK_DIR}/TAF/testArtifacts/reports/edgex/log.html ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/integration-test.html
   ;;
   *)

--- a/docs/run-tests-on-local.md
+++ b/docs/run-tests-on-local.md
@@ -19,13 +19,17 @@ export WORK_DIR=${HOME}/edgex-taf
 # Arguments for run-tests.sh
 ${ARCH}: x86_64 | arm64
 ${SECURITY_SERVICE_NEEDED}: false | true
-${TEST_STRATEGY}: 1 (functional)
-${TEST_SERVICE}: all (default) | device-virtual | device-modbus | ${directory} under TAF/testScenarios/functionalTest/V2-API 
+${TEST_STRATEGY}: functional-test | integration-test
+${TEST_SERVICE}:  v2-api (default) | device-virtual | device-modbus | ${directory} under TAF/testScenarios/functionalTest/V2-API | mqtt (integration-test) | redis (integration-test)
 ${DEPLOY_SERVICES}: no-deployment(If edgex services are deployed in place, use 'no-deployment' Otherwise, leave it empty.)
 
 cd ${WORK_DIR}/TAF/utils/scripts/docker
-sh run-tests.sh ${ARCH} ${SECURITY_SERVICE_NEEDED} ${TEST_STRATEGY} ${DEPLOY_SERVICES}
-# ex. sh run-tests.sh x86_64 false 1 no-deployment
+sh run-tests.sh ${ARCH} ${SECURITY_SERVICE_NEEDED} ${TEST_STRATEGY} ${TEST_SERVICE} ${DEPLOY_SERVICES}
+
+# If using x86_64, no need for secuity, adopt for functional-test, choose "v2-api" for test_service and edgex service are deployed in place, it should be:
+ex. sh run-tests.sh x86_64 false functional-test v2-api no-deployment
+# If using x86_64, no need for secuity, adopt for integration-test, choose "mqtt" for test_service and edgex service are not deployed in place, it should be:
+ex. sh run-tests.sh x86_64 false integration-test mqtt 
 ```
 
 #### View the test report
@@ -55,20 +59,22 @@ Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/
 3. Prepare test environment:
     ``` bash
     # Arguments for get-compose-file.sh
-    ${USE_DB}: -redis | -mongo (mongo is not supported from hanoi release)
     ${ARCH}: x86_64 | arm64
     ${USE_SECURITY}: - (false) | -security- (true)
+    ${USE_SHA1}:jakarta
+    ${TEST_STRATEGY}: functional-test | integration-test
 
     # Fetch the latest docker-compose file
     cd ${HOME}/edgex-taf/TAF/utils/scripts/docker
-    sh get-compose-file.sh ${USE_DB} ${ARCH} ${USE_SECURITY}
-    # ex. sh get-compose-file.sh -redis x86_64 -
+    sh get-compose-file.sh ${USE_ARCH} ${USE_SECURITY} ${USE_SHA1} ${TEST_STRATEGY}
+    # ex. sh get-compose-file.sh x86_64 - jakarta functional-test
     
     # Export the following environment variables.
     export WORK_DIR=${HOME}/edgex-taf
-    export ARCH=x86_64
     export SECURITY_SERVICE_NEEDED=false
     export COMPOSE_IMAGE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest
+    #export COMPOSE_IMAGE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest
+    #If running on arm64, edgex-compose file should be 'edgex-compose-arm64'.
     ```
 #### Run Tests
 `View the test report after finishing a python command, otherwise the report will be overridden after executing next command. Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/v2-api-test.html.`
@@ -143,3 +149,4 @@ Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/
 **Keyword level example**
 
 ![image](./images/test_report_keyword.png)
+


### PR DESCRIPTION
path: edgex-taf/TAF/utils/scripts/docker

-revise arguments in run-tests.sh
-change value of ${USE_SHA1} to "jakarta" in files as shown below
 get-compose-file-perfermance/exec_performance_metrics.sh/get-compose-file.sh

path: edgex-taf/TAF/docs
-update run-tests-on-local.md

fix #609

Signed-off-by: melody <melody@iotechsys.com>