### PR TITLE
fix: Get correct event on performance metrics collection

### DIFF
--- a/TAF/config/performance-metrics/configuration.py
+++ b/TAF/config/performance-metrics/configuration.py
@@ -128,7 +128,7 @@ ALLOWABLE_OUTLIER = 5
 
 
 # Suite: 5_event_exported_time
-# Loop time for sending ping request
+# Loop time for retrieve mqtt events
 EXPORTED_LOOP_TIMES = 10
 
 # Export time threshold value (in milliseconds)

--- a/TAF/testCaseModules/keywords/performance-metrics-collection/EventExportedTime.py
+++ b/TAF/testCaseModules/keywords/performance-metrics-collection/EventExportedTime.py
@@ -26,12 +26,15 @@ class EventExportedTime(object):
         full_subscriber_logs = subprocess.check_output("python ${WORK_DIR}/TAF/utils/src/setup/mqtt-subscriber.py edgex-events origin perf",
                                                        shell=True)
         subscriber_logs = full_subscriber_logs.decode("utf-8").replace("Connected to MQTT with result code 0", "")
-        events = subscriber_logs.split('Got mqtt export data!!')
-        for event in events:
-            if "deviceName" in event:
-                event_str = event.split('\n')
-                event_json = json.loads(event_str[2])
-                event_json['received'] = int(event_str[1])
+        messages = subscriber_logs.split('Got mqtt export data!!')
+        for message in messages:
+            if "deviceName" in message:
+                full_msg_list = message.split('\n')
+                msg_list = list(filter(None, full_msg_list))  # Remove empty value
+                for line in msg_list:
+                    if "origin" in line:
+                        event_json = json.loads(line)
+                        event_json['received'] = int(msg_list[0])
 
                 if str(devices[0]) == event_json['deviceName']:
                     device_int.append(event_json)


### PR DESCRIPTION
Fix #652 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->