### PR TITLE
feat: Add core-data metrics test

### DIFF
--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -256,3 +256,62 @@ Get Consul Token
     ...     shell=True  stderr=STDOUT  output_encoding=UTF-8
     ${token}  Evaluate  json.loads('''${result.stdout}''')  json
     [Return]  ${token}[SecretID]
+
+Set Telemetry ${config}=${value} For ${service_name} On Consul
+    ${service_layer}  Set Variable If  'device' in """${service_name}"""  devices
+                      ...              'core' in """${service_name}"""  core
+    ${telemetry_path}  Set Variable  /v1/kv/edgex/${service_layer}/${CONSUL_CONFIG_VERSION}/${service_name}/Writable/Telemetry
+    ${path}  Set Variable   ${telemetry_path}/${config}
+    Update Service Configuration On Consul  ${path}  ${value}
+    Sleep  500ms  # Waiting for the configuration available
+
+Run Redis Subscriber Progress And Output
+    [Arguments]  ${topic}  ${keyword}
+    ${current_time}  get current epoch time
+    ${secty}  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Set Variable  true
+              ...       ELSE  Set Variable  false
+    ${handle}  Start process  python ${WORK_DIR}/TAF/utils/src/setup/redis-subscriber.py ${topic} ${keyword} ${secty} &
+    ...                shell=True  stdout=${WORK_DIR}/TAF/testArtifacts/logs/redis-subscriber-${current_time}.log
+    ...                stderr=${WORK_DIR}/TAF/testArtifacts/logs/redis-error-${current_time}.log
+    Set Test Variable  ${subscriber_file}  redis-subscriber-${current_time}.log
+    sleep  2s
+    [Return]  ${handle}
+
+Metrics ${metrics_name} Should Be Received
+    ${content}  grep file  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}  Payload
+    ${last_msg}  Get Line  ${content}  -1
+    ${last_msg_json}  Evaluate  json.loads('''${last_msg}''')
+    ${decode_payload}  Evaluate  base64.b64decode('${last_msg_json}[Payload]').decode('utf-8')  modules=base64
+    ${payload}  Evaluate  json.loads('''${decode_payload}''')
+    Should Be Equal As Strings  ${metrics_name}  ${payload}[name]
+    FOR  ${INDEX}  IN RANGE  len(${payload}[fields])
+        Run Keyword If  '${payload}[fields][${INDEX}][name]' == 'counter-count'
+        ...     Should Not Be Equal As Integers  0  ${payload}[fields][${INDEX}][value]
+    END
+
+No Metrics With Name ${metrics_name} Received
+    ${file_size}  Get File Size  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}
+    Run Keyword If  ${file_size} == 0  Log  No Any Metrics Received With The Topic
+    ...       ELSE  No ${metrics_name} Found In File
+
+
+No ${metrics_name} Found In File
+    ${content}  grep file  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}  Payload
+    ${count}  Get Line Count  ${content}
+    FOR  ${INDEX}  IN RANGE  ${count}
+        ${json_msg}  Get Line  ${content}  ${INDEX}
+        ${encode_payload}  Evaluate  json.loads('''${json_msg}''')
+        ${decode_payload}  Evaluate  base64.b64decode('${encode_payload}[Payload]').decode('utf-8')  modules=base64
+        ${payload}  Evaluate  json.loads('''${decode_payload}''')
+        Should Not Be Equal As Strings  ${metrics_name}  ${payload}[name]
+    END
+    Log  No ${metrics_name} Received In MessageBus With The Topic
+
+Run MQTT Subscriber Progress And Output
+    [Arguments]  ${topic}  ${keyword}
+    ${current_time}  get current epoch time
+    Start process  python ${WORK_DIR}/TAF/utils/src/setup/mqtt-subscriber.py ${topic} ${keyword} arg &
+    ...            shell=True  stdout=${WORK_DIR}/TAF/testArtifacts/logs/mqtt-subscriber-${current_time}.log
+    ...            stderr=${WORK_DIR}/TAF/testArtifacts/logs/mqtt-error-${current_time}.log
+    Set Test Variable  ${subscriber_file}  mqtt-subscriber-${current_time}.log
+    sleep  1s

--- a/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
@@ -84,18 +84,6 @@ Event Has Been Pushed To Core Data
     Should Return Status Code "200" And events
     Should Be Equal As Strings  ${content}[events][0][deviceName]  ${device_name}
 
-Run Redis Subscriber Progress And Output
-    [Arguments]  ${topic}
-    ${current_time}  get current epoch time
-    ${secty}  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Set Variable  true
-              ...       ELSE  Set Variable  false
-    ${handle}  Start process  python ${WORK_DIR}/TAF/utils/src/setup/redis-subscriber.py ${topic} ${device_name} ${secty} &
-    ...                shell=True  stdout=${WORK_DIR}/TAF/testArtifacts/logs/subscriber-${current_time}.log
-    ...                stderr=${WORK_DIR}/TAF/testArtifacts/logs/error-${current_time}.log
-    Set Test Variable  ${subscriber_file}  subscriber-${current_time}.log
-    sleep  2s
-    [Return]  ${handle}
-
 Get device data by device ${device} and command ${command} with ${params}
     Get device ${device} read command ${command} with ${params}
     Should return status code "200"

--- a/TAF/testScenarios/integrationTest/UC_device_service/messagebus_false.robot
+++ b/TAF/testScenarios/integrationTest/UC_device_service/messagebus_false.robot
@@ -19,7 +19,7 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/messagebus_false.log
 DeviceService006-Send get command with parameters ds-pushevent=no and ds-returnevent=no when messagebus is disabled
     Set Test Variable  ${device_name}  messagebus-false-device-5
     ${params}  Create Dictionary  ds-pushevent=no  ds-returnevent=no
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200"
@@ -33,7 +33,7 @@ DeviceService006-Send get command with parameters ds-pushevent=no and ds-returne
 DeviceService007-Send get command with parameters ds-pushevent=yes and ds-returnevent=no when messagebus is disabled
     Set Test Variable  ${device_name}  messagebus-false-device-6
     ${params}  Create Dictionary  ds-pushevent=yes  ds-returnevent=no
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200"
@@ -47,7 +47,7 @@ DeviceService007-Send get command with parameters ds-pushevent=yes and ds-return
 DeviceService008-Send get command with parameters ds-pushevent=no and ds-returnevent=yes when messagebus is disabled
     Set Test Variable  ${device_name}  messagebus-false-device-7
     ${params}  Create Dictionary  ds-pushevent=no  ds-returnevent=yes
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200" And event
@@ -60,7 +60,7 @@ DeviceService008-Send get command with parameters ds-pushevent=no and ds-returne
 DeviceService009-Send get command with parameters ds-pushevent=yes and ds-returnevent=yes when messagebus is disabled
     Set Test Variable  ${device_name}  messagebus-false-device-8
     ${params}  Create Dictionary  ds-pushevent=yes  ds-returnevent=yes
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200" And event
@@ -72,7 +72,7 @@ DeviceService009-Send get command with parameters ds-pushevent=yes and ds-return
 
 DeviceService010-Create Events by REST API when messagebus is disabled
     Set Test Variable  ${device_name}  messagebus-false-device-10
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.core.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.core.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     And Generate Event Sample  Event  ${device_name}  ${PREFIX}-Sample-Profile  ${PREFIX}_GenerateDeviceValue_UINT8_RW  Simple Reading  
     When Create Event With ${device_name} And ${PREFIX}-Sample-Profile And ${PREFIX}_GenerateDeviceValue_UINT8_RW

--- a/TAF/testScenarios/integrationTest/UC_device_service/messagebus_true.robot
+++ b/TAF/testScenarios/integrationTest/UC_device_service/messagebus_true.robot
@@ -17,7 +17,7 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/messagebus_true.log
 DeviceService001-Send get command with parameters ds-pushevent=no and ds-returnevent=no when messagebus is enabled
     Set Test Variable  ${device_name}  messagebus-true-device-1
     ${params}  Create Dictionary  ds-pushevent=no  ds-returnevent=no
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200"
@@ -30,7 +30,7 @@ DeviceService001-Send get command with parameters ds-pushevent=no and ds-returne
 DeviceService002-Send get command with parameters ds-pushevent=yes and ds-returnevent=no when messagebus is enabled
     Set Test Variable  ${device_name}  messagebus-true-device-2
     ${params}  Create Dictionary  ds-pushevent=yes  ds-returnevent=no
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200"
@@ -43,7 +43,7 @@ DeviceService002-Send get command with parameters ds-pushevent=yes and ds-return
 DeviceService003-Send get command with parameters ds-pushevent=no and ds-returnevent=yes when messagebus is enabled
     Set Test Variable  ${device_name}  messagebus-true-device-3
     ${params}  Create Dictionary  ds-pushevent=no  ds-returnevent=yes
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200" And event
@@ -56,7 +56,7 @@ DeviceService003-Send get command with parameters ds-pushevent=no and ds-returne
 DeviceService004-Send get command with parameters ds-pushevent=yes and ds-returnevent=yes when messagebus is enabled
     Set Test Variable  ${device_name}  messagebus-true-device-4
     ${params}  Create Dictionary  ds-pushevent=yes  ds-returnevent=yes
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.device.*  ${device_name}
     Given Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${PREFIX}_GenerateDeviceValue_INT8_RW with ${params}
     Then Should Return Status Code "200" And event
@@ -69,7 +69,7 @@ DeviceService004-Send get command with parameters ds-pushevent=yes and ds-return
 DeviceService005-Customize PublishTopicPrefix works correctly when using Redis message bus
     Set Test Variable  ${device_name}  messagebus-true-device-5
     ${params}  Create Dictionary  ds-pushevent=yes  ds-returnevent=yes
-    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.custom.*
+    ${handle}  Run Redis Subscriber Progress And Output  edgex.events.custom.*  ${device_name}
     Given Set PublishTopicPrefix=edgex/events/custom For device-virtual On Consul
     And Set SubscribeTopic=edgex/events/custom/# For core-data On Consul
     And Create Device For device-virtual With Name ${device_name}

--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_store_forward.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_store_forward.robot
@@ -27,7 +27,6 @@ StoreAndForward001 - Stored data is exported after connecting to http server
     And Start HTTP Server And Received Exported Data Contains ${PREFIX}_GenerateDeviceValue_UINT8_RW
     [Teardown]  Run Keywords  Delete device by name ${device_name}
                 ...           AND  Delete all events by age
-                ...           AND  Terminate Process  ${handle}  kill=True
 
 StoreAndForward002 - Stored data is cleared after the maximum configured retires
     ${configurations}  Create Dictionary  Enabled=true  RetryInterval=3s  MaxRetryCount=3

--- a/TAF/testScenarios/integrationTest/UC_metrics/core_data_metrics_mqtt.robot
+++ b/TAF/testScenarios/integrationTest/UC_metrics/core_data_metrics_mqtt.robot
@@ -1,0 +1,63 @@
+*** Settings ***
+Library      TAF/testCaseModules/keywords/setup/edgex.py
+Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
+Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+Resource     TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+Suite Setup  Run keywords  Setup Suite
+...                   AND  Set Suite Variable  ${interval}  2
+...                   AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                   AND  Set Telemetry Interval=${interval}s For core-data On Consul
+Suite Teardown  Run keywords  Terminate All Processes
+...                      AND  Delete all events by age
+...                      AND  Set Telemetry Interval=30s For core-data On Consul
+...                      AND  Run Teardown Keywords
+Force Tags      MessageQueue=MQTT
+
+*** Variables ***
+${SUITE}          Core Data Metrics Test - MQTT bus
+${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/core_data_metrics_mqtt.log
+
+
+*** Test Cases ***
+DataMetricsMQTT001-Enable EventsPersisted And Verify Metrics is Publish to MessageBus
+    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/core-data/EventsPersisted  Payload
+    And Set Test Variable  ${device_name}  events-persisted-true
+    And Set Telemetry Metrics/EventsPersisted=true For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then Metrics EventsPersisted Should Be Received
+    [Teardown]  Run keywords  Delete device by name ${device_name}
+                ...           AND  Set Telemetry Metrics/EventsPersisted=false For core-data On Consul
+
+DataMetricsMQTT002-Disable EventsPersisted And Verify Metrics isn't Publish to MessageBus
+    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/core-data/EventsPersisted  Payload
+    And Set Test Variable  ${device_name}  events-persisted-false
+    And Set Telemetry Metrics/EventsPersisted=false For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then No Metrics With Name EventsPersisted Received
+    [Teardown]  Delete device by name ${device_name}
+
+DataMetricsMQTT003-Enable ReadingsPersisted And Verify Metrics is Publish to MessageBus
+    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/core-data/ReadingsPersisted  Payload
+    And Set Test Variable  ${device_name}  readings-persisted-true
+    And Set Telemetry Metrics/ReadingsPersisted=true For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then Metrics ReadingsPersisted Should Be Received
+    [Teardown]  Run keywords  Delete device by name ${device_name}
+                ...      AND  Set Telemetry Metrics/ReadingsPersisted=false For core-data On Consul
+
+DataMetricsMQTT004-Disable ReadingsPersisted And Verify Metrics isn't Publish to MessageBus
+    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/core-data/ReadingsPersisted  Payload
+    And Set Test Variable  ${device_name}  readings-persisted-false
+    And Set Telemetry Metrics/ReadingsPersisted=false For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then No Metrics With Name ReadingsPersisted Received
+    [Teardown]  Delete device by name ${device_name}
+

--- a/TAF/testScenarios/integrationTest/UC_metrics/core_data_metrics_redis.robot
+++ b/TAF/testScenarios/integrationTest/UC_metrics/core_data_metrics_redis.robot
@@ -1,0 +1,62 @@
+*** Settings ***
+Library      TAF/testCaseModules/keywords/setup/edgex.py
+Resource     TAF/testCaseModules/keywords/common/commonKeywords.robot
+Resource     TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
+Resource     TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+Suite Setup  Run keywords  Setup Suite
+...                   AND  Set Suite Variable  ${interval}  2
+...                   AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+...                   AND  Set Telemetry Interval=${interval}s For core-data On Consul
+Suite Teardown  Run keywords  Terminate All Processes
+...                      AND  Delete all events by age
+...                      AND  Set Telemetry Interval=30s For core-data On Consul
+...                      AND  Run Teardown Keywords
+Force Tags      MessageQueue=redis
+
+*** Variables ***
+${SUITE}          Core Data Metrics Test - Redis Bus
+${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/core_data_metrics_redis.log
+
+
+*** Test Cases ***
+DataMetricsRedis001-Enable EventsPersisted And Verify Metrics is Publish to MessageBus
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.core-data.EventsPersisted  telemetry
+    And Set Test Variable  ${device_name}  events-persisted-true
+    And Set Telemetry Metrics/EventsPersisted=true For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then Metrics EventsPersisted Should Be Received
+    [Teardown]  Run keywords  Delete device by name ${device_name}
+                ...           AND  Set Telemetry Metrics/EventsPersisted=false For core-data On Consul
+
+DataMetricsRedis002-Disable EventsPersisted And Verify Metrics isn't Publish to MessageBus
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.core-data.EventsPersisted  telemetry
+    And Set Test Variable  ${device_name}  events-persisted-false
+    And Set Telemetry Metrics/EventsPersisted=false For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then No Metrics With Name EventsPersisted Received
+    [Teardown]  Delete device by name ${device_name}
+
+DataMetricsRedis003-Enable ReadingsPersisted And Verify Metrics is Publish to MessageBus
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.core-data.ReadingsPersisted  telemetry
+    And Set Test Variable  ${device_name}  readings-persisted-true
+    And Set Telemetry Metrics/ReadingsPersisted=true For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then Metrics ReadingsPersisted Should Be Received
+    [Teardown]  Run keywords  Delete device by name ${device_name}
+                ...      AND  Set Telemetry Metrics/ReadingsPersisted=false For core-data On Consul
+
+DataMetricsRedis004-Disable ReadingsPersisted And Verify Metrics isn't Publish to MessageBus
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.core-data.ReadingsPersisted  telemetry
+    And Set Test Variable  ${device_name}  readings-persisted-false
+    And Set Telemetry Metrics/ReadingsPersisted=false For core-data On Consul
+    And Create Device For device-virtual With Name ${device_name}
+    When Create multiple events
+    And Sleep  ${interval}
+    Then No Metrics With Name ReadingsPersisted Received
+    [Teardown]  Delete device by name ${device_name}


### PR DESCRIPTION
Add tests for redis and mqtt both messagebus on separate file.

Fix #681

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->