### PR TITLE
fix: Update status code to 400 when sending device profile with invalid units

### DIFF
--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Deviceresource.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Deviceresource.robot
@@ -100,7 +100,7 @@ ErrProfileResourcePOST009 - Add deviceResource with invalid units value
     When Create Device Resources Contain invalid Units Value
     Then Should Return Status Code "207"
     And Should Return Content-Type "application/json"
-    And Item Index All Should Contain Status Code "500"
+    And Item Index All Should Contain Status Code "400"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     And Resources Should Not Be Added in ${test_profile}
     [Teardown]  Run Keywords  Update Service Configuration On Consul  ${uomValidationPath}  false

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Uploadfile.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative-Uploadfile.robot
@@ -86,7 +86,7 @@ ErrProfilePOSTUpload008 - Create device profile by upload file with deviceComman
 ErrProfilePOSTUpload009 - Create device profile by upload file with invalid units property
     Given Update Service Configuration On Consul  ${uomValidationPath}  true
     When Modify Device Profile Test-Profile-4 With invalid Units Value
-    Then Should Return Status Code "500"
+    Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Update Service Configuration On Consul  ${uomValidationPath}  false

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/POST-Negative.robot
@@ -93,6 +93,6 @@ ErrProfilePOST009 - Create device profile with invalid units value
     When Create A Profile Test-Profile-1 With invalid Units Value
     Then Should Return Status Code "207"
     And Should Return Content-Type "application/json"
-    And Item Index All Should Contain Status Code "500"
+    And Item Index All Should Contain Status Code "400"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Update Service Configuration On Consul  ${uomValidationPath}  false

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative-UploadFile.robot
@@ -113,7 +113,7 @@ ErrProfilePUTUpload009 - Update device profile by upload file and the update fil
     And Update Service Configuration On Consul  ${uomValidationPath}  true
     And Update Units Value In Profile Test-Profile-3 To invalid
     When Upload File NEW-Test-Profile-3.yaml To Update Device Profile
-    Then Should Return Status Code "500"
+    Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     And Resource Units Should Not Be Updated in Test-Profile-3

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/PUT-Negative.robot
@@ -117,7 +117,7 @@ ErrProfilePUT009 - Update device profile with invalid units value
     And Set Profile Units Value To invalid
     When Update Device Profile ${deviceProfile}
     Then Should Return Status Code "207"
-    And Item Index 0 Should Contain Status Code "500"
+    And Item Index 0 Should Contain Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     And Resource Units Should Not Be Updated in Test-Profile-1


### PR DESCRIPTION
Fix #710

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->