### PR TITLE
fix: Update backward compose file to use external MQTT broker

### DIFF
--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -270,7 +270,7 @@ Run Redis Subscriber Progress And Output
     Sleep  2s
     Set Test Variable  ${handle_redis}  ${handle}
 
-Run MQTT Subscriber Progress And Output  # Only available on mqtt message bus testcases
+Run MQTT Subscriber Progress And Output
     [Arguments]  ${topic}  ${keyword}=CorrelationID  ${expected_msg_count}=1  ${port}=${BROKER_PORT}
     ...          ${secure}=${SECURITY_SERVICE_NEEDED}  ${duration}=30  # duration only enabled when expected_msg_count=-1
     ${current_time}  get current epoch time
@@ -289,3 +289,10 @@ Decode Base64 String
     ${payload}  Evaluate  json.loads('''${decode_payload}''')
     Log  ${payload}
     [Return]  ${payload}
+
+Dump Last 100 lines Log And Service Config  # For Debug use
+    [Arguments]  ${service_name}  ${url}
+    Set Test Variable  ${url}  ${url}
+    Query Config
+    ${logs}  Run Process  docker logs edgex-${service_name} -n 100  shell=True  stderr=STDOUT  output_encoding=UTF-8
+    Log  ${logs.stdout}

--- a/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
@@ -103,6 +103,9 @@ Event With Device ${device_name} Should Not Be Received by Redis Subscriber ${fi
     Should Be Empty  ${redis_subscriber}
 
 Event With Device ${device_name} Should Be Received by Redis Subscriber ${filename}
+    Run Keyword And Continue On Failure  Wait Until Keyword Succeeds  5x  1s  File Should Not Be Empty  ${WORK_DIR}/TAF/testArtifacts/logs/${filename}
+    # Show last 100 lines for debug
+    Dump Last 100 lines Log And Service Config  device-virtual  ${deviceServiceUrl}
     ${redis_subscriber}=  grep file  ${WORK_DIR}/TAF/testArtifacts/logs/${filename}  ${device_name}
     run keyword if  "${device_name}" not in """${redis_subscriber}"""
     ...             fail  No data received by redis subscriber

--- a/TAF/testScenarios/integrationTest/UC_device_service/messagebus_false.robot
+++ b/TAF/testScenarios/integrationTest/UC_device_service/messagebus_false.robot
@@ -84,7 +84,12 @@ DeviceService010-Create Events by REST API when messagebus is disabled
 
 *** Keywords ***
 Set UseMessageBus=${value} For device-virtual On Consul
-   ${path}=  Set Variable  /v1/kv/edgex/devices/${CONSUL_CONFIG_VERSION}/device-virtual/Device/UseMessageBus
-   Update Service Configuration On Consul  ${path}  ${value}
-   Restart Services  device-virtual
-
+    ${path}=  Set Variable  /v1/kv/edgex/devices/${CONSUL_CONFIG_VERSION}/device-virtual/Device/UseMessageBus
+    Update Service Configuration On Consul  ${path}  ${value}
+    Restart Services  device-virtual
+    Set Suite Variable  ${url}  ${deviceServiceUrl}
+    FOR  ${INDEX}  IN RANGE  5
+        Query Ping
+        Run Keyword If  ${response} == 200  Exit For Loop
+        ...       ELSE  Sleep  5s
+    END

--- a/TAF/testScenarios/integrationTest/UC_device_service/messagebus_true.robot
+++ b/TAF/testScenarios/integrationTest/UC_device_service/messagebus_true.robot
@@ -92,3 +92,9 @@ Set ${config}=${value} For ${service_name} On Consul
     ${service}  Run Keyword If  'core' in """${service_name}"""  Fetch From Right  ${service_name}  -
                 ...       ELSE  Set Variable  ${service_name}
     Restart Services  ${service}
+    Set Test Variable  ${url}  ${deviceServiceUrl}
+    FOR  ${INDEX}  IN RANGE  5
+        Query Ping
+        Run Keyword If  ${response} == 200  Exit For Loop
+        ...       ELSE  Sleep  5s
+    END

--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_data_to_backend.robot
@@ -51,13 +51,13 @@ ExportErr001 - Export events/readings to unreachable HTTP backend
                 ...           AND  Delete all events by age
 
 ExportErr002 - Export events/readings to unreachable MQTT backend
-    Given Stop Services  mqtt-broker
+    Given Run Keyword And Ignore Error  Stop Services  mqtt-broker  mqtt-taf-broker
     And Create Device For device-virtual With Name mqtt-export-error-device
     When Get device data by device mqtt-export-error-device and command ${PREFIX}_GenerateDeviceValue_INT64_RW
     Then No exported logs found on configurable application service  app-mqtt-export
     [Teardown]  Run keywords  Delete device by name mqtt-export-error-device
                 ...           AND  Delete all events by age
-                ...           AND  Restart Services  mqtt-broker
+                ...           AND  Run Keyword And Ignore Error  Restart Services  mqtt-broker  mqtt-taf-broker
 
 
 *** Keywords ***

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -93,7 +93,13 @@ for compose in ${COMPOSE_FILE}; do
   done
 
   sed -i '/PROFILE_VOLUME_PLACE_HOLDER: {}/d' ${compose}.yml
-  sed -i 's/\MQTT_BROKER_ADDRESS_PLACE_HOLDER/tcp:\/\/${EXTERNAL_BROKER_HOSTNAME}:1883/g' ${compose}.yml
+
+  # Update for backward competibility test
+  if [ "${USE_SHA1}" = "main" ]; then
+    sed -i 's/\MQTT_BROKER_ADDRESS_PLACE_HOLDER/tcp:\/\/${EXTERNAL_BROKER_HOSTNAME}:1883/g' ${compose}.yml
+  else
+    sed -i 's/\MQTT_BROKER_ADDRESS_PLACE_HOLDER/${EXTERNAL_BROKER_HOSTNAME}/g' ${compose}.yml
+  fi
 
   sed -i 's/\LOGLEVEL: INFO/LOGLEVEL: DEBUG/g' ${compose}.yml
   sed -i '/METRICSMECHANISM/d' ${compose}.yml  # remove METRICSMECHANISM env variable to allow change on Consul


### PR DESCRIPTION
Fix #730
1. Update backward compose file to use external MQTT broker
2. Adjust some tests to avoid test failed on backward compatibility test sometimes
3. Dump service logs for debug.

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->