### PR TITLE
fix: Implment north-south messaging negative test for device-onvif-camera

### DIFF
--- a/TAF/testCaseModules/keywords/core-command/externalSystem.robot
+++ b/TAF/testCaseModules/keywords/core-command/externalSystem.robot
@@ -101,7 +101,7 @@ Should Return Error Code 1 And RequestID Should Be The Same As Request
     Should Be Equal As Integers  1  ${last_msg_json}[ErrorCode]
 
 Get Response Message
-    Wait Until Keyword Succeeds  10x  1s  File Should Not Be Empty  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}
+    Wait Until Keyword Succeeds  10x  2s  File Should Not Be Empty  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}
     ${content}  grep file  ${WORK_DIR}/TAF/testArtifacts/logs/${subscriber_file}  Payload
     ${count}  Get Line Count  ${content}
     ${last_msg}  Run Keyword If  ${count} > 1  Get Line  ${content}  -1

--- a/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
@@ -59,7 +59,8 @@ Get A Read Command
     Set Test Variable  ${set_reading_value}  ${set_reading_value}
 
 Create Device For ${SERVICE_NAME} With Name ${name}
-    ${device}  Set device values  ${SERVICE_NAME}  ${PREFIX}-Sample-Profile
+    ${device}  Run Keyword If  '${SERVICE_NAME}' == 'device-onvif-camera'  Set device values  device-onvif-camera  onvif-camera
+               ...       ELSE  Set device values  ${SERVICE_NAME}  ${PREFIX}-Sample-Profile
     Set To Dictionary  ${device}  name=${name}
     Generate Devices  ${device}
     Create Device With ${Device}

--- a/TAF/testData/core-metadata/device_protocol.json
+++ b/TAF/testData/core-metadata/device_protocol.json
@@ -13,5 +13,17 @@
             "Address": "simple01",
             "Port": "300"
         }
+    },
+    "device-onvif-camera": {
+        "Onvif": {
+            "Address": "192.168.12.123",
+            "Port": "80",
+            "FriendlyName": "Home camera",
+            "MACAddress": "aa:bb:cc:dd:ee:ff"
+        },
+        "CustomMetadata": {
+            "Location": "Front door",
+            "Color": "Black and white"
+        }
     }
 }

--- a/TAF/testScenarios/functionalTest/V2-API/core-command/device/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-command/device/GET-Negative.robot
@@ -82,12 +82,16 @@ ErrCommandGET010 - Get specified device read command when device OperatingState 
     [Teardown]  Delete device by name ${device_name}
 
 ErrCommandGET011 - Get unavailable HTTP device read command
-    # device-camera
+    # device-onvif-camera
     ${default_response_time_threshold}  Set Variable  8000    # normally exceed default 1200ms
-    When Run Keyword And Expect Error  *  Get Specified Device Camera001 Read Command OnvifDeviceInformation
+    Given Set Test Variable  ${device_name}  Camera01
+    And Set Test Variable  ${resource_name}  NetworkConfiguration
+    And Create Device For device-onvif-camera With Name ${device_name}
+    When Run Keyword And Expect Error  *  Get Specified Device ${device_name} Read Command ${resource_name}
     And Should Return Status Code "500" or "503"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete device by name ${device_name}
 
 ErrCommandGET012 - Get unavailable Modbus device read command
     # device-modbus

--- a/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Positive.robot
+++ b/TAF/testScenarios/functionalTest/V2-API/core-metadata/provisionwatcher/GET-Positive.robot
@@ -17,8 +17,8 @@ ProWatcherGET001 - Query all provision watcher
     And Create Provision Watcher ${provisionwatcher}
     When Query All Provision Watchers
     Then Should Return Status Code "200" And provisionWatchers
-    And totalCount Should be 3
-    And Should Be True  len(${content}[provisionWatchers]) == 3
+    And totalCount Should be 4  # device-onvif-camera will auto create a provision watcher
+    And Should Be True  len(${content}[provisionWatchers]) == 4
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete Multiple Provision Watchers Sample, Profiles Sample And Services Sample
@@ -29,8 +29,8 @@ ProWatcherGET002 - Query all provision watcher with offset
     When Query All Provision Watchers With offset=1
     Then Should Return Status Code "200" And provisionWatchers
     And Should Return Content-Type "application/json"
-    And totalCount Should be 3
-    And Should Be True  len(${content}[provisionWatchers]) == 2
+    And totalCount Should be 4  # device-onvif-camera will auto create a provision watcher
+    And Should Be True  len(${content}[provisionWatchers]) == 3
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete Multiple Provision Watchers Sample, Profiles Sample And Services Sample
 
@@ -39,7 +39,7 @@ ProWatcherGET003 - Query all provision watcher with limit
     And Create Provision Watcher ${provisionwatcher}
     When Query All Provision Watchers With limit=2
     Then Should Return Status Code "200" And provisionWatchers
-    And totalCount Should be 3
+    And totalCount Should be 4  # device-onvif-camera will auto create a provision watcher
     And Should Return Content-Type "application/json"
     And Should Be True  len(${content}[provisionWatchers]) == 2
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms

--- a/TAF/testScenarios/integrationTest/UC_north_south_messaging/GET-Negative.robot
+++ b/TAF/testScenarios/integrationTest/UC_north_south_messaging/GET-Negative.robot
@@ -101,12 +101,15 @@ ErrNSMessagingGET010 - Get specified device read command when device OperatingSt
                 ...      AND  Terminate Process  ${handle_mqtt}  kill=True
 
 ErrNSMessagingGET011 - Get unavailable HTTP device read command
-    [Tags]  skipped
-    # device-camera
-    Given Subscribe MQTT Topic 'edgex/command/response/#'
-    When Get Command With Camera01 From External MQTT Broker
-    Then Should Return Error Code "1"
-    And RequestID Should Be Correct
+    # device-onvif-camera
+    Given Set Test Variable  ${device_name}  Camera01
+    And Set Test Variable  ${resource_name}  NetworkConfiguration
+    And Create Device For device-onvif-camera With Name ${device_name}
+    And Run MQTT Subscriber Progress And Output  ${RES_TOPIC}  Payload  1  ${EX_BROKER_PORT}  false
+    When Get Command From External MQTT Broker
+    Then Should Return Error Code 1 And RequestID Should Be The Same As Request
+    [Teardown]  Run keywords  Delete device by name ${device_name}
+                ...      AND  Terminate Process  ${handle_mqtt}  kill=True
 
 ErrNSMessagingGET012 - Get unavailable Modbus device read command
     # device-modbus


### PR DESCRIPTION
Implment north-south messaging negative test for device-onvif-camera
The case was skipped on #728

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->