### PR TITLE
fix: typo for setting CONSUL_CONFIG_BASE_ENDPOINT variable

### DIFF
--- a/TAF/testScenarios/integrationTest/UC_metadata_notifications/metadata_notifications.robot
+++ b/TAF/testScenarios/integrationTest/UC_metadata_notifications/metadata_notifications.robot
@@ -98,7 +98,7 @@ Update Device
     Update devices ${Device}
 
 Set Core-Metadata PostDeviceChanges=${bool}
-    ${path}=  Set Variable ${CONSUL_CONFIG_BASE_ENDPOINT}/core-metadata/Notifications/PostDeviceChanges
+    ${path}=  Set Variable  ${CONSUL_CONFIG_BASE_ENDPOINT}/core-metadata/Notifications/PostDeviceChanges
     Update Service Configuration On Consul  ${path}  ${bool}
     Restart Services  metadata
 


### PR DESCRIPTION
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->