### PR TITLE
fix: remove redundant space on get-compose-file.sh

### DIFF
--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -64,10 +64,10 @@ for compose in ${COMPOSE_FILE}; do
   # Enable North-South Messaging
   if [ "${TEST_STRATEGY}" = "integration-test" ]; then
     sed -n "/^\ \ command:/,/^  [a-z].*:$/p" ${compose}.yml | sed '$d' > tmp/command.yml
-    sed -i '/MESSAGEBUS _EXTERNAL_URL/d' tmp/command.yml
-    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS _EXTERNAL_ENABLED: true' tmp/command.yml
-    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS _EXTERNAL_URL: tcp:\/\/${EXTERNAL_BROKER_HOSTNAME}:1883' tmp/command.yml
-    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS _EXTERNAL_RETAIN: false' tmp/command.yml
+    sed -i '/MESSAGEBUS_EXTERNAL_URL/d' tmp/command.yml
+    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS_EXTERNAL_ENABLED: true' tmp/command.yml
+    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS_EXTERNAL_URL: tcp:\/\/${EXTERNAL_BROKER_HOSTNAME}:1883' tmp/command.yml
+    sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ MESSAGEBUS_EXTERNAL_RETAIN: false' tmp/command.yml
     sed -i "/^\ \ command:/,/^  [a-z].*:$/{//!d}; /^\ \ command:/d" ${compose}.yml
     sed -i "/services:/ r tmp/command.yml" ${compose}.yml
   fi


### PR DESCRIPTION
remove redundant space on get-compose-file.sh

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->