### PR TITLE
fix: Update script to override profileDir path

### DIFF
--- a/TAF/utils/scripts/docker/deploy-edgex.sh
+++ b/TAF/utils/scripts/docker/deploy-edgex.sh
@@ -17,8 +17,10 @@ else
 
     # copy device service default configuration in the res to TAF/config/{service}/res
     docker cp edgex-${PROFILE}:/res/configuration.toml ${WORK_DIR}/TAF/config/${PROFILE}
-    sed -i '/DevicesDir/d' ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
-    sed -i "s/ProfilesDir.*/ProfilesDir = '\\$CONFIG_DIR'/g" ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
+    sed -i "s/\[Device\]/[Device_old]/" ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
+    echo "" >> ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
+    echo "[Device]" >> ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
+    echo "ProfilesDir = \"$CONFIG_DIR\"" >> ${WORK_DIR}/TAF/config/${PROFILE}/configuration.toml
 
   done
 

--- a/docs/run-tests-on-local.md
+++ b/docs/run-tests-on-local.md
@@ -72,7 +72,7 @@ Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/
     # Export the following environment variables.
     export WORK_DIR=${HOME}/edgex-taf
     export SECURITY_SERVICE_NEEDED=false
-    export COMPOSE_IMAGE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest
+    export COMPOSE_IMAGE=docker:20.10.18
     ```
 #### Run Tests
 `View the test report after finishing a python command, otherwise the report will be overridden after executing next command. Open the report file by browser: ${WORK_DIR}/TAF/testArtifacts/reports/cp-edgex/v2-api-test.html.`


### PR DESCRIPTION
Update script to override profileDir path according to the common-config feature Close #779
Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run `python3 -m TUC --exclude Skipped --include deploy-base-service -u deploy.robot -p default` and check whether the config is changed.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->