### PR TITLE
fix: Set timeout for Run Process keyword to fix timeout issue when security enabled

### DIFF
--- a/TAF/testScenarios/integrationTest/UC_end_to_end/export_store_forward.robot
+++ b/TAF/testScenarios/integrationTest/UC_end_to_end/export_store_forward.robot
@@ -100,14 +100,14 @@ Start HTTP Server And Received Exported Data Contains ${keyword}
 
 Found Retry Log ${number} Times In ${service_name} Logs From ${timestamp}
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service_name} ${timestamp}
-    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8
+    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=10s
     ${retry_lines}  Get Lines Containing String  ${logs.stdout}.encode()  1 stored data items found for retrying
     ${retry_times}  Get Line Count  ${retry_lines}
     Should Be Equal As Integers  ${retry_times}  ${number}
 
 Found Remove Log In ${service_name} Logs From ${timestamp}
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service_name} ${timestamp}
-    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8
+    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=10s
     ${retry_lines}  Get Lines Containing String  ${logs.stdout}.encode()  1 stored data items will be removed post retry
     ${retry_times}  Get Line Count  ${retry_lines}
     Should Be Equal As Integers  ${retry_times}  1
@@ -123,7 +123,7 @@ Found Retry Log From ${timestamp} After Restarting ${service_name}
     Dump Last 100 lines Log And Service Config  ${service_name}  http://${BASE_URL}:${APP_HTTP_EXPORT_PORT}
 
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service_name} ${timestamp}
-    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8
+    ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=10s
     ${retry_lines}  Get Lines Containing String  ${logs.stdout}.encode()  1 stored data items found for retrying
     Should Not Be Empty   ${retry_lines}
 


### PR DESCRIPTION
Fix #798 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->