### PR TITLE
fix: Enable CORS configuration security test

### DIFF
--- a/TAF/testCaseModules/keywords/common/commonKeywords.robot
+++ b/TAF/testCaseModules/keywords/common/commonKeywords.robot
@@ -341,3 +341,6 @@ Secrets Should be Stored To Consul
     Query Service Configuration On Consul  ${secrets_data_path}
     ${secrets_key_consul_value}  Evaluate  base64.b64decode('${content}[0][Value]').decode('utf-8')  modules=base64
     Should Be Equal  ${secrets_key_consul_value}  ${secrets_value}
+
+Should Return Status Code "${statusCode_0}" or "${statusCode_1}"
+    Should Match Regexp  "${response}"  (${statusCode_0}|${statusCode_1})

--- a/TAF/testScenarios/functionalTest/API/core-command/device/GET-Negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-command/device/GET-Negative.robot
@@ -101,7 +101,3 @@ ErrCommandGET012 - Get unavailable Modbus device read command
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete device by name ${device_name}
-
-*** Keywords ***
-Should Return Status Code "500" or "503"
-    Should Match Regexp  "${response}"  (500|503)

--- a/TAF/testScenarios/integrationTest/UC_CORS_configuration/cors_configuration.robot
+++ b/TAF/testScenarios/integrationTest/UC_CORS_configuration/cors_configuration.robot
@@ -1,12 +1,9 @@
 *** Settings ***
 Resource        TAF/testCaseModules/keywords/common/commonKeywords.robot
 Suite Setup  Run Keywords   Setup Suite
-             ...      AND  Skip If  $SECURITY_SERVICE_NEEDED == 'true'
-             ...      AND  Set Service.CORSConfiguration.EnableCORS to true For core-metadata On Consul
-             ...      AND  Set Service.CORSConfiguration.CORSAllowCredentials to true For core-metadata On Consul
-             ...      AND  Restart Services  core-metadata
-Suite Teardown  Run Keywords  Set Service.CORSConfiguration.EnableCORS to false For core-metadata On Consul
-                ...      AND  Restart Services  core-metadata
+             ...      AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+             ...      AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'false'  Enable CORS For Individual Service
+Suite Teardown  Run Keywords  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'false'  Disable CORS For Individual Service
                 ...      AND  Run Teardown Keywords
 Force Tags      MessageBus=redis
 
@@ -16,33 +13,27 @@ ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/cors_configuration.log
 ${coreMetadataUrl}  ${URI_SCHEME}://${BASE_URL}:${CORE_METADATA_PORT}
 
 *** Test Cases ***
-CORS001-Enable CORS without Origin header
-    ${header_keys}  Create List  Access-Control-Request-Method
-    ${header_values}  Create List  GET
-    ${unexpected_headers}  Create List  Access-Control-Expose-Headers  Access-Control-Allow-Origin
-                         ...     Access-Control-Allow-Credentials  Vary
-    When Send GET Request With Headers  ${header_keys}  ${header_values}
-    Then Header Should Not Contain  ${unexpected_headers}
-
-CORS002-Enable CORS and receive a prefligt request
+CORS001-Enable CORS and receive a prefligt request
     ${header_keys}  Create List  Access-Control-Request-Method  Origin
     ${header_values}  Create List  GET  http://localhost
     ${expected_headers}  Create List  Vary  Access-Control-Allow-Headers  Access-Control-Allow-Methods
                          ...   Access-Control-Allow-Origin  Access-Control-Allow-Credentials  Access-Control-Max-Age
     ${unexpected_headers}  Create List  Access-Control-Expose-Headers
     When Send OPTIONS Request With Headers  ${header_keys}  ${header_values}
-    Then Header Should Contain  ${expected_headers}
+    Then Should Return Status Code "200" or "204"
+    And Header Should Contain  ${expected_headers}
     And Header Should Not Contain  ${unexpected_headers}
 
-CORS003-Enable CORS and receive an actual request
+CORS002-Enable CORS and receive an actual request
     ${header_keys}  Create List  Access-Control-Request-Method  Origin
     ${header_values}  Create List  GET  http://localhost
     ${expected_headers}  Create List  Access-Control-Expose-Headers  Access-Control-Allow-Origin
                          ...     Access-Control-Allow-Credentials  Vary
     When Send GET Request With Headers  ${header_keys}  ${header_values}
-    Then Header Should Contain  ${expected_headers}
+    Then Should Return Status Code "200" or "204"
+    And Header Should Contain  ${expected_headers}
 
-CORS004-Enable CORS and receive a prefligt request with CORSAllowCredentials=false
+CORS003-Enable CORS and receive a prefligt request with CORSAllowCredentials=false
     [Setup]  Run Keywords  Set Service.CORSConfiguration.CORSAllowCredentials to false For core-metadata On Consul
              ...      AND  Restart Services  core-metadata
     ${header_keys}  Create List  Access-Control-Request-Method  Origin
@@ -51,25 +42,28 @@ CORS004-Enable CORS and receive a prefligt request with CORSAllowCredentials=fal
                          ...   Access-Control-Allow-Origin  Access-Control-Max-Age
     ${unexpected_headers}  Create List  Access-Control-Expose-Headers
     When Send OPTIONS Request With Headers  ${header_keys}  ${header_values}
-    Then Header Should Contain  ${expected_headers}
+    Then Should Return Status Code "200" or "204"
+    And Header Should Contain  ${expected_headers}
     And Header Should Not Contain  ${unexpected_headers}
 
-CORS005-Enable CORS and receive an actual request with CORSAllowCredentials=false
+CORS004-Enable CORS and receive an actual request with CORSAllowCredentials=false
     [Setup]  Run Keywords  Set Service.CORSConfiguration.CORSAllowCredentials to false For core-metadata On Consul
              ...      AND  Restart Services  core-metadata
     ${header_keys}  Create List  Access-Control-Request-Method  Origin
     ${header_values}  Create List  GET  http://localhost
     ${expected_headers}  Create List  Access-Control-Expose-Headers  Access-Control-Allow-Origin  Vary
     When Send GET Request With Headers  ${header_keys}  ${header_values}
-    Then Header Should Contain  ${expected_headers}
+    Then Should Return Status Code "200" or "204"
+    And Header Should Contain  ${expected_headers}
 
-CORS006-Not enable CORS
-    [Setup]  Run Keywords  Set Service.CORSConfiguration.EnableCORS to false For core-metadata On Consul
-             ...      AND  Restart Services  core-metadata
+CORS005-Not enable CORS
+    [Setup]  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Skip
+             ...       ELSE  Disable CORS For Individual Service
     ${unexpected_headers}  Create List  Access-Control-Expose-Headers  Access-Control-Allow-Origin
                          ...     Access-Control-Allow-Credentials  Vary
     When Send GET Request Without CORS Headers
-    Then Header Should Not Contain  ${unexpected_headers}
+    Then Should Return Status Code "200" or "204"
+    And Header Should Not Contain  ${unexpected_headers}
 
 *** Keywords ***
 Set Service.CORSConfiguration.${config} to ${value} For ${service_name} On Consul
@@ -83,16 +77,19 @@ Send ${method} Request With Headers
         Set To Dictionary  ${headers}  ${key}=${value}
     END
     Create Session  Ping  url=${coreMetadataUrl}  disable_warnings=true
-    ${resp}  Run Keyword If  "${method}" == "GET"  GET On Session  Ping  api/${API_VERSION}/ping  headers=${headers}  expected_status=200
-             ...    ELSE IF  "${method}" == "OPTIONS"  OPTIONS On Session  Ping  api/${API_VERSION}/ping  headers=${headers}  expected_status=200
+    ${resp}  Run Keyword If  "${method}" == "GET"  GET On Session  Ping  api/${API_VERSION}/ping  headers=${headers}
+             ...    ELSE IF  "${method}" == "OPTIONS"  OPTIONS On Session  Ping  api/${API_VERSION}/ping  headers=${headers}
              ...       ELSE  Fail  Invalid Method: ${method}
     Set Test Variable  ${response_headers}  ${resp.headers}
+    Set Test Variable  ${response}  ${resp.status_code}
+
 
 Send GET Request Without CORS Headers
     ${headers}=  Create Dictionary  Authorization=Bearer ${jwt_token}
     Create Session  Ping  url=${coreMetadataUrl}  disable_warnings=true
-    ${resp}  GET On Session  Ping  api/${API_VERSION}/ping  headers=${headers}  expected_status=200
+    ${resp}  GET On Session  Ping  api/${API_VERSION}/ping  headers=${headers}
     Set Test Variable  ${response_headers}  ${resp.headers}
+    Set Test Variable  ${response}  ${resp.status_code}
 
 Header Should Contain
     [Arguments]  ${headers}
@@ -105,3 +102,12 @@ Header Should Not Contain
     FOR  ${header}  IN  @{headers}
         Should Not Contain  ${response_headers}  ${header}
     END
+
+Enable CORS For Individual Service
+    Set Service.CORSConfiguration.EnableCORS to true For core-metadata On Consul
+    Set Service.CORSConfiguration.CORSAllowCredentials to true For core-metadata On Consul
+    Restart Services  core-metadata
+
+Disable CORS For Individual Service
+    Set Service.CORSConfiguration.EnableCORS to false For core-metadata On Consul
+    Restart Services  core-metadata

--- a/TAF/utils/scripts/docker/get-compose-file.sh
+++ b/TAF/utils/scripts/docker/get-compose-file.sh
@@ -117,11 +117,18 @@ for compose in ${COMPOSE_FILE}; do
     sed -i 's/published: \"59901\"/published: "59911"/g' tmp/device-modbus_1.yml
     sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ EDGEX_INSTANCE_NAME: 1' tmp/device-modbus_1.yml
     sed -i "/services:/ r tmp/device-modbus_1.yml" ${compose}.yml
-    # Add secrets for device-modbus_1
+
     if [ "${USE_SECURITY}" = '-security-' ]; then
+      # Add secrets for device-modbus_1
       sed -i '/EDGEX_ADD_REGISTRY_ACL_ROLES/ s/$/,device-modbus_1/' ${compose}.yml
       sed -i '/EDGEX_ADD_KNOWN_SECRETS/ s/$/,redisdb[device-modbus_1],message-bus[device-modbus_1]/' ${compose}.yml
       sed -i '/EDGEX_ADD_SECRETSTORE_TOKENS/ s/$/,device-modbus_1/' ${compose}.yml
+      # Enable CORS Configuration
+      sed -n "/^\ \ security-proxy-setup:/,/^  [a-z].*:$/p" ${compose}.yml | sed '$d' > tmp/security-proxy-setup.yml
+      sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS: true' tmp/security-proxy-setup.yml
+      sed -i '/\ \ \ \ environment:/a \ \ \ \ \ \ EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS: true' tmp/security-proxy-setup.yml
+      sed -i "/^\ \ security-proxy-setup:/,/^  [a-z].*:$/{//!d}; /^\ \ security-proxy-setup:/d" ${compose}.yml
+      sed -i "/services:/ r tmp/security-proxy-setup.yml" ${compose}.yml
     fi
 
     # Add second modbus simulator


### PR DESCRIPTION
Closes #850 
Enable CORS configuration security test and remove invalid test `Enable CORS without Origin header` .

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->