### PR TITLE
fix: Update the timing of getting timestamp when query service log

### DIFF
--- a/TAF/testScenarios/functionalTest/API/support-scheduler/intervalaction/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/API/support-scheduler/intervalaction/POST-Positive.robot
@@ -58,8 +58,6 @@ Create Pre-Created HalfSecond Interval And PingScheduler Intervalaction By Confi
     FOR  ${kv}  IN  &{intervalAction}
       Update Service Configuration On Consul  ${consul_path}/IntervalActions/${intervalAction_name}/${kv}[0]  ${kv}[1]
     END
-    ${timestamp}=  Get current epoch time
-    Set Test Variable  ${timestamp}  ${timestamp}
     Restart Services  support-scheduler
     Wait Until Keyword Succeeds  10x  1s  Ping Scheduler Service
 
@@ -79,6 +77,9 @@ Delete Pre-Created HalfSecond Interval And PingScheduler IntervalAction
 Pre-Created Interval And IntervalAction Should Be Created
     Query Interval By Name ${interval_name}
     Should Return Status Code "200"
+    # Get timestamp for querying logs in keyword IntervalAction Should Be Executed Every ScheduleIntervalTime
+    ${timestamp}=  Get current epoch time
+    Set Test Variable  ${timestamp}  ${timestamp}
     Query IntervalAction By Name ${intervalAction_name}
     Should Return Status Code "200"
 

--- a/TAF/testScenarios/integrationTest/UC_metrics/app_services_metrics_redis.robot
+++ b/TAF/testScenarios/integrationTest/UC_metrics/app_services_metrics_redis.robot
@@ -93,7 +93,7 @@ APPServicesMetricsRedis005-Enable InvalidMessagesReceived And Verify Metrics is 
                 ...      AND  Set Telemetry Metrics/InvalidMessagesReceived=false For app-sample On Consul
 
 APPServicesMetricsRedis006-Enable PipelineMessagesProcessed And Verify Metrics is Publish to MessageBus
-    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineMessagesProcessed  telemetry  6
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineMessagesProcessed  telemetry  9
     And Set Test Variable  ${device_name}  pipeline-messages-processed
     And Set Topics For app-samle PerTopicPipelines On Consul
     And Set Telemetry Metrics/PipelineMessagesProcessed=true For app-sample On Consul
@@ -106,7 +106,7 @@ APPServicesMetricsRedis006-Enable PipelineMessagesProcessed And Verify Metrics i
                 ...      AND  Set Telemetry Metrics/PipelineMessagesProcessed=false For app-sample On Consul
 
 APPServicesMetricsRedis007-Enable PipelineMessageProcessingTime And Verify Metrics is Publish to MessageBus
-    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineMessageProcessingTime  telemetry  6
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineMessageProcessingTime  telemetry  9
     And Set Test Variable  ${device_name}  pipeline-messages-processing-time
     And Set Topics For app-samle PerTopicPipelines On Consul
     And Create Device For device-virtual With Name ${device_name}
@@ -119,7 +119,7 @@ APPServicesMetricsRedis007-Enable PipelineMessageProcessingTime And Verify Metri
                 ...      AND  Set Telemetry Metrics/PipelineMessageProcessingTime=false For app-sample On Consul
 
 APPServicesMetricsRedis008-Enable PipelineProcessingErrors And Verify Metrics is Publish to MessageBus
-    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineProcessingErrors  telemetry  6
+    Given Run Redis Subscriber Progress And Output  edgex.telemetry.app-sample.PipelineProcessingErrors  telemetry  9
     And Set Test Variable  ${device_name}  pipeline-processing-errors
     And Set app-sample Functions HTTPExport
     And Set PerTopicPipelines float ExecutionOrder HTTPExport

--- a/TAF/testScenarios/integrationTest/UC_retention/core_data_retention.robot
+++ b/TAF/testScenarios/integrationTest/UC_retention/core_data_retention.robot
@@ -23,7 +23,7 @@ ${interval}  2s
 CoreDataRetention001 - core-data retention is executed if reading count is over MaxCap value
     When Create 3 Events
     And Sleep  ${interval}
-    And Wait Until Keyword Succeeds  5  1s  Found Purge Log in core-data
+    And Wait Until Keyword Succeeds  3x  2s  Found Purge Log in core-data
     Then Stored Event Count Should Be Equal 1
     And Stored Readings Are Belong To Stored Events
     [Teardown]  Delete all events by age

--- a/TAF/testScenarios/integrationTest/UC_retention/notifications_retention.robot
+++ b/TAF/testScenarios/integrationTest/UC_retention/notifications_retention.robot
@@ -26,7 +26,7 @@ ${interval}  3s
 NotificationsRetention001 - notifications retention is executed if reading count is over MaxCap value
     When Create Subscriptions 1 And Notifications 10
     And Sleep  ${interval}
-    And Wait Until Keyword Succeeds  5  1s  Found Purge Log in support-notifications
+    And Wait Until Keyword Succeeds  3x  2s  Found Purge Log in support-notifications
     Then Stored Notifications Count Should Be Less Than: 10
     And Stored Transmissions Are Belong To Stored Notifications
     [Teardown]  Run Keywords  Cleanup All Notifications And Transmissions
@@ -93,5 +93,5 @@ Found Purge Log in ${service}
     ${current_time}  Get current epoch time
     ${timestamp}  Evaluate  ${current_time}-5
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service} ${timestamp}
-             ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=5s
+             ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=10s
     Should Contain  ${logs.stdout}  Purging the notification


### PR DESCRIPTION
Closes #885 

- To fix failure tests for store and forward.
- Update the invalid parameter for retention tests
- Update script to avoid the related test of intervalaction and metrics tests got failure

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->