### PR TITLE
fix: Update the timing to get the query timestamp for NotificationsRetention001 test

### DIFF
--- a/TAF/testScenarios/integrationTest/UC_retention/notifications_retention.robot
+++ b/TAF/testScenarios/integrationTest/UC_retention/notifications_retention.robot
@@ -25,6 +25,8 @@ ${interval}  3s
 *** Test Cases ***
 NotificationsRetention001 - notifications retention is executed if reading count is over MaxCap value
     When Create Subscriptions 1 And Notifications 10
+    ${timestamp}  Get current epoch time
+    And Set Test Variable  ${timestamp}  ${timestamp}
     And Sleep  ${interval}
     And Wait Until Keyword Succeeds  3x  2s  Found Purge Log in support-notifications
     Then Stored Notifications Count Should Be Less Than: 10
@@ -90,8 +92,7 @@ Create Subscriptions ${subscriptions_num} And Notifications ${notifications_num}
     Create Notification ${notification}
 
 Found Purge Log in ${service}
-    ${current_time}  Get current epoch time
-    ${timestamp}  Evaluate  ${current_time}-5
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service} ${timestamp}
              ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=10s
+    Log  ${logs.stdout}
     Should Contain  ${logs.stdout}  Purging the notification


### PR DESCRIPTION
Closes #888 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->