### PR TITLE
fix: Add environment variable file while shutting down services

### DIFF
--- a/TAF/utils/scripts/docker/shutdown.sh
+++ b/TAF/utils/scripts/docker/shutdown.sh
@@ -6,11 +6,13 @@ APPSERVICE=${2:-}
 if [ "$TEST_STRATEGY" = "PerformanceMetrics" ]; then
   docker run --rm -v ${WORK_DIR}:${WORK_DIR} -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
         --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --env CONFIG_DIR=${CONFIG_DIR} \
+        --env-file ${WORK_DIR}/TAF/utils/scripts/docker/common-taf.env \
         --security-opt label:disable ${COMPOSE_IMAGE} docker compose \
         -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose${APPSERVICE}.yml" down -v
 else
   docker run --rm -v ${WORK_DIR}:${WORK_DIR} -w ${WORK_DIR} -v /var/run/docker.sock:/var/run/docker.sock \
         --env WORK_DIR=${WORK_DIR} --env PROFILE=${PROFILE} --env CONFIG_DIR=${CONFIG_DIR} \
+        --env-file ${WORK_DIR}/TAF/utils/scripts/docker/common-taf.env \
         --security-opt label:disable ${COMPOSE_IMAGE} docker compose \
         -f "${WORK_DIR}/TAF/utils/scripts/docker/docker-compose.yml" down -v
 fi


### PR DESCRIPTION
Closes #890 
Lost shutdown script on PR #891 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->