### PR TITLE
fix: Modify FOOTPRINT_THRESHOLD value to 2.1

### DIFF
--- a/TAF/config/performance-metrics/configuration.py
+++ b/TAF/config/performance-metrics/configuration.py
@@ -97,7 +97,7 @@ DEVICE_REST_BINARY_ARM64 = 25.73
 
 # Footprint threshold value
 # ex. 1.5 = prior release + 50%
-FOOTPRINT_THRESHOLD = 1.2
+FOOTPRINT_THRESHOLD = 2.1
 
 # Suite: 2_service_startup_time
 # Retry setting to fetch service startup time


### PR DESCRIPTION
#894 

Increase the FOOTPRINT_THRESHOLD value to `2.1`, because the binary size increases  more than 1.3 times.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) Not necessary
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->