### PR TITLE
fix: Update tests to allow empty profile and empty protocol when creating device

### DIFF
--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Negative.robot
@@ -62,26 +62,6 @@ ErrDevicePATCH005 - Update device with serviceName validate error
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete Multiple Devices Sample And Profiles Sample
 
-ErrDevicePATCH006 - Update device with profileName validate error
-    # Empty profileName
-    Given Create Devices And Generate Multiple Devices Sample For Updating Data
-    And Set To Dictionary  ${Device}[1][device]  profileName=${EMPTY}
-    When Update Devices ${Device}
-    Then Should Return Status Code "400"
-    And Should Return Content-Type "application/json"
-    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete Multiple Devices Sample And Profiles Sample
-
-ErrDevicePATCH007 - Update device with protocols validate error
-    # Empty protocols
-    Given Create Devices And Generate Multiple Devices Sample For Updating Data
-    And Set To Dictionary  ${Device}[2][device]  protocols=&{EMPTY}
-    When Update Devices ${Device}
-    Then Should Return Status Code "400"
-    And Should Return Content-Type "application/json"
-    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete Multiple Devices Sample And Profiles Sample
-
 ErrDevicePATCH008 - Update device with adminState value validate error
     # Out of optional value for adminState
     Given Create Devices And Generate Multiple Devices Sample For Updating Data

--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Positive.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Positive.robot
@@ -33,6 +33,26 @@ DevicePATCH002 - Update device with device service and profile
     And Device Profile/Device Should Be Updated
     [Teardown]  Delete Multiple Devices Sample And Profiles Sample
 
+DevicePATCH003 - Update device with empty protocol
+    Given Create Devices And Generate Multiple Devices Sample For Updating Data
+    And Set To Dictionary  ${Device}[2][device]  protocols=&{EMPTY}
+    When Update Devices ${Device}
+    Then Should Return Status Code "207"
+    And Item Index All Should Contain Status Code "200"
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete Multiple Devices Sample And Profiles Sample
+
+DevicePATCH004 - Update device with empty profileName
+    Given Create Devices And Generate Multiple Devices Sample For Updating Data
+    And Set To Dictionary  ${Device}[1][device]  profileName=${EMPTY}
+    When Update Devices ${Device}
+    Then Should Return Status Code "207"
+    And Item Index All Should Contain Status Code "200"
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete Multiple Devices Sample And Profiles Sample
+
 *** Keywords ***
 Device ${type} Should Be Updated
     ${list}=  Create List  Test-Device  Test-Device-Locked  Test-Device-Disabled  Test-Device-AutoEvents

--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Negative.robot
@@ -68,28 +68,6 @@ ErrDevicePOST005 - Create device with serviceName validate error
     [Teardown]  Delete multiple device profiles by names
     ...         Test-Profile-1  Test-Profile-2  Test-Profile-3
 
-ErrDevicePOST006 - Create device with profileName validate error
-    # Empty profileName
-    Given Create Multiple Profiles And Generate Multiple Devices Sample
-    And Set To Dictionary  ${Device}[1][device]  profileName=${EMPTY}
-    When Create Device With ${Device}
-    Then Should Return Status Code "400"
-    And Should Return Content-Type "application/json"
-    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete multiple device profiles by names
-    ...         Test-Profile-1  Test-Profile-2  Test-Profile-3
-
-ErrDevicePOST007 - Create device with protocols validate error
-    # Empty protocols
-    Given Create Multiple Profiles And Generate Multiple Devices Sample
-    And Set To Dictionary  ${Device}[1][device]  protocols=&{EMPTY}
-    When Create Device With ${Device}
-    Then Should Return Status Code "400"
-    And Should Return Content-Type "application/json"
-    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-    [Teardown]  Delete multiple device profiles by names
-    ...         Test-Profile-1  Test-Profile-2  Test-Profile-3
-
 ErrDevicePOST008 - Create device with adminState value validate error
     # Out of optional value for adminState
     Given Create Multiple Profiles And Generate Multiple Devices Sample

--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Positive.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Positive.robot
@@ -57,3 +57,23 @@ DevicePOST004 - Create device with Chinese naming
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Run Keywords  Delete device by name ${test_device_name}
                 ...      AND  Delete device profile by name  ${test_profile_name}
+
+DevicePOST005 - Create device with empty profileName
+    Given Create Multiple Profiles And Generate Multiple Devices Sample
+    And Set To Dictionary  ${Device}[1][device]  profileName=${EMPTY}
+    When Create Device With ${Device}
+    Then Should Return Status Code "207"
+    And Item Index All Should Contain Status Code "201" And id
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete Multiple Devices Sample And Profiles Sample
+
+DevicePOST006 - Create device with empty protocol
+    Given Create Multiple Profiles And Generate Multiple Devices Sample
+    And Set To Dictionary  ${Device}[2][device]  protocols=&{EMPTY}
+    When Create Device With ${Device}
+    Then Should Return Status Code "207"
+    And Item Index All Should Contain Status Code "201" And id
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete Multiple Devices Sample And Profiles Sample


### PR DESCRIPTION
Closes #900 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) Not necessary
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->