### PR TITLE
fix: Update status code to 400 when creating device and the assigned device profile doesn't exist

### DIFF
--- a/TAF/testScenarios/functionalTest/API/core-data/reading/GET-negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-data/reading/GET-negative.robot
@@ -18,7 +18,7 @@ ErrReadingGET001 - Query all readings with non-int value on offset
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
 
 ErrReadingGET002 - Query all readings with offset out of range
-    When Run Keyword And Expect Error  *  Query All Readings With offset=-1
+    When Run Keyword And Expect Error  *  Query All Readings With offset=-2
     Then Should Return Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms

--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Negative-II.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/PATCH-Negative-II.robot
@@ -26,7 +26,7 @@ ErrDevicePATCH012 - Update device with non-existent profileName
     And Set To Dictionary  ${Device}[1][device]  profileName=Non-existent
     When Update Devices ${Device}
     And Item Index 0,2,3 Should Contain Status Code "200"
-    And Item Index 1 Should Contain Status Code "404"
+    And Item Index 1 Should Contain Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete Multiple Devices Sample And Profiles Sample

--- a/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Negative-II.robot
+++ b/TAF/testScenarios/functionalTest/API/core-metadata/device/POST-Negative-II.robot
@@ -31,7 +31,7 @@ ErrDevicePOST011 - Create device with non-existent device profile name
     When Create Device With ${Device}
     Then Should Return Status Code "207"
     And Item Index 0,1,3 Should Contain Status Code "201" And id
-    And Item Index 2 Should Contain Status Code "404"
+    And Item Index 2 Should Contain Status Code "400"
     And Should Return Content-Type "application/json"
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Run Keywords  Delete Multiple Devices By Names

--- a/TAF/testScenarios/integrationTest/UC_metrics/app_services_metrics.robot
+++ b/TAF/testScenarios/integrationTest/UC_metrics/app_services_metrics.robot
@@ -73,10 +73,11 @@ APPServicesMetricsMQTT003-Enable MqttExportSize And Verify Metrics is Publish to
                 ...      AND  Restart Services  ${APP_SERVICE_NAME}
 
 APPServicesMetricsMQTT004-Enable MessagesReceived And Verify Metrics is Publish to MessageBus
-    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/MessagesReceived  payload  2
-    And Set Test Variable  ${device_name}  message-received
+    Given Set Test Variable  ${device_name}  message-received
+    And Set ${APP_SERVICE_NAME} Functions SetResponseData
     And Set Telemetry Metrics/MessagesReceived=true For ${APP_SERVICE_NAME} On Registry Service
     And Restart Services  ${APP_SERVICE_NAME}
+    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/MessagesReceived  payload  2
     And Create Device For device-virtual With Name ${device_name}
     When Get device data by device ${device_name} and command ${INT8_CMD} with ds-pushevent=true
     And Sleep  ${interval}
@@ -88,11 +89,11 @@ APPServicesMetricsMQTT004-Enable MessagesReceived And Verify Metrics is Publish 
 
 APPServicesMetricsMQTT005-Enable InvalidMessagesReceived And Verify Metrics is Publish to MessageBus
     ${publish_msg}  Set Variable  Invalid Message
-    Given Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/InvalidMessagesReceived  payload  2
-    And Set Test Variable  ${device_name}  invalid-message-received
+    Given Set Test Variable  ${device_name}  invalid-message-received
+    And Set ${APP_SERVICE_NAME} Functions SetResponseData
     And Create Device For device-virtual With Name ${device_name}
     And Set Telemetry Metrics/InvalidMessagesReceived=true For ${APP_SERVICE_NAME} On Registry Service
-    And Restart Services  ${APP_SERVICE_NAME}
+    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/InvalidMessagesReceived  payload  2
     When Run process  python ${WORK_DIR}/TAF/utils/src/setup/mqtt-publisher.py edgex/events/${device_name} "${publish_msg}" ${BROKER_PORT} ${SECURITY_SERVICE_NEEDED}
          ...          shell=True  timeout=10s
     And Sleep  ${interval_ex}
@@ -103,11 +104,12 @@ APPServicesMetricsMQTT005-Enable InvalidMessagesReceived And Verify Metrics is P
 
 APPServicesMetricsMQTT006-Enable PipelineMessagesProcessed And Verify Metrics is Publish to MessageBus
     Given Set Test Variable  ${device_name}  pipeline-messages-processed
+    And Set ${APP_SERVICE_NAME} Functions SetResponseData
     And Set Topics For ${APP_SERVICE_NAME} PerTopicPipelines On Registry Service
     And Create Device For device-virtual With Name ${device_name}
-    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineMessagesProcessed  payload  6
     And Set Telemetry Metrics/PipelineMessagesProcessed=true For ${APP_SERVICE_NAME} On Registry Service
     And Restart Services  ${APP_SERVICE_NAME}
+    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineMessagesProcessed  payload  6
     When Get Multiple Device Data With Commands ${COMMANDS}
     And Sleep  ${interval_ex}
     Then Received Metrics PipelineMessagesProcessed For All Pipelines And counter-count Should Not Be 0
@@ -118,11 +120,12 @@ APPServicesMetricsMQTT006-Enable PipelineMessagesProcessed And Verify Metrics is
 
 APPServicesMetricsMQTT007-Enable PipelineMessageProcessingTime And Verify Metrics is Publish to MessageBus
     Given Set Test Variable  ${device_name}  pipeline-messages-processing-time
+    And Set ${APP_SERVICE_NAME} Functions SetResponseData
     And Set Topics For ${APP_SERVICE_NAME} PerTopicPipelines On Registry Service
     And Create Device For device-virtual With Name ${device_name}
-    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineMessageProcessingTime  payload  6
     And Set Telemetry Metrics/PipelineMessageProcessingTime=true For ${APP_SERVICE_NAME} On Registry Service
     And Restart Services  ${APP_SERVICE_NAME}
+    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineMessageProcessingTime  payload  6
     When Get Multiple Device Data With Commands ${COMMANDS}
     And Sleep  ${interval_ex}
     Then Received Metrics PipelineMessageProcessingTime For All Pipelines And timer-count Should Not Be 0
@@ -138,9 +141,9 @@ APPServicesMetricsMQTT008-Enable PipelineProcessingErrors And Verify Metrics is 
     And Set PerTopicPipelines int8-16 ExecutionOrder HTTPExport
     And Set Topics For ${APP_SERVICE_NAME} PerTopicPipelines On Registry Service
     And Create Device For device-virtual With Name ${device_name}
-    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineProcessingErrors  payload  6
     And Set Telemetry Metrics/PipelineProcessingErrors=true For ${APP_SERVICE_NAME} On Registry Service
     And Restart Services  ${APP_SERVICE_NAME}
+    And Run MQTT Subscriber Progress And Output  edgex/telemetry/${APP_SERVICE_NAME}/PipelineProcessingErrors  payload  6
     When Get Multiple Device Data With Commands ${COMMANDS}
     And Sleep  ${interval_ex}
     Then Received Metrics PipelineProcessingErrors For All Pipelines And counter-count Should Not Be 0


### PR DESCRIPTION
Closes #924 

1. Update status code to 400 when creating device and the assigned device profile doesn't exist
2. Not use offset=-1 on nagetive test
3. Update app-service metric steps to make test smoothly

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->