### PR TITLE
fix: disable query reading total count when offset=-1

### DIFF
--- a/TAF/testScenarios/functionalTest/API/core-data/reading/GET-positive-II.robot
+++ b/TAF/testScenarios/functionalTest/API/core-data/reading/GET-positive-II.robot
@@ -38,6 +38,15 @@ ReadingGET011 - Query readings by device name and resource name between start/en
     And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     [Teardown]  Delete All Events By Age
 
+ReadingGET012 - Query all readings with offset=-1
+    Given Create Multiple Events
+    When Query All Readings With offset=-1
+    Then Should Return Status Code "200"
+    And totalCount Should be 0
+    And Should Be True  len(${content}[readings]) == 9
+    And Should Return Content-Type "application/json"
+    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
+    [Teardown]  Delete All Events By Age
 
 *** Keywords ***
 All ${number} Readings Should Contain deviceName ${device_name} And resourceName ${resource_name}

--- a/TAF/testScenarios/integrationTest/UC_retention/core_data_retention.robot
+++ b/TAF/testScenarios/integrationTest/UC_retention/core_data_retention.robot
@@ -28,15 +28,17 @@ CoreDataRetention001 - core-data retention is executed if reading count is over 
     And Sleep  3s
     And Wait Until Keyword Succeeds  3x  1s  Purge Log Found in core-data
     Then Stored Event Count Should Less Than ${maxCap} and Large Than ${minCap}
-    [Teardown]  Delete all events by age
+    [Teardown]  Run Keywords  Run Keyword And Ignore Error  Delete Device By Name ${deviceName}
+                ...      AND  Delete all events by age
 
 CoreDataRetention002 - core-data retention is not executed if reading count is less than DefaultMaxCap value
     Given Set Test Variable  ${deviceName}  data-retention-device2
-    And Create Events With AutoEvent Interval 1s
+    And Create Events With AutoEvent Interval 2s
     And Sleep  3s
     Then No Purge Log Found in core-data
-    And Stored Event Count Should Less Than ${maxCap} and Large Than ${minCap}
-    [Teardown]  Delete all events by age
+    And Stored Event Count Should Less Than ${maxCap}
+    [Teardown]  Run Keywords  Run Keyword And Ignore Error  Delete Device By Name ${deviceName}
+                ...      AND  Delete all events by age
 
 *** Keywords ***
 Set Core-Data Retention
@@ -57,16 +59,34 @@ Create ${range} events with ${command}
 
 
 Stored Event Count Should Less Than ${max} and Large Than ${min}
+    ${purge_log}  Get Lines Containing String  ${service_log}  purge events by duration
+    ${purge_log_line}  Get Line  ${purge_log}  -1
+    ${purge_time_arr}  Get Regexp Matches  ${purge_log_line}  \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d+
+    @{purge_time}  Split String  ${purge_time_arr}[0]  .
+    ${purge_second}  Convert Date  ${purge_time}[0]  result_format=epoch
+    ${purge_second}  Convert To Integer  ${purge_second}
+    ${compare_time}  Set Variable  ${purge_second}${purge_time}[1]
+
+    ${count}  Set Variable  ${0}
+    Query all events
+    FOR  ${INDEX}  IN RANGE  len(${content}[events])
+        IF  ${content}[events][${INDEX}][origin] >= ${compare_time}
+            ${count}  Evaluate  ${count} + 1
+        END
+    END
+    Should Be True  ${min} <= ${count} <= ${max}
+
+Stored Event Count Should Less Than ${max}
     ${time}  Get Current Nanoseconds Epoch Time
     ${compare_time}  Evaluate  ${time} - 3000000000
     ${count}  Set Variable  ${0}
     Query all events
     FOR  ${INDEX}  IN RANGE  len(${content}[events])
-        IF  ${content}[events][${INDEX}][origin] <= ${compare_time}
+        IF  ${content}[events][${INDEX}][origin] >= ${compare_time}
             ${count}  Evaluate  ${count} + 1
         END
     END
-    Should Be True  ${min} <= ${count} <= ${max}
+    Should Be True  ${count} <= ${max}
 
 Get Readings Ids From Event API
     ${ids}  Create List
@@ -78,14 +98,16 @@ Get Readings Ids From Event API
     RETURN  ${ids}
 
 Purge Log Found in ${service}
-    ${logs}  Get Log in ${service}
-    Should Contain  ${logs}  purge events by duration
+    Get Log in core-data
+    Should Contain  ${service_log}  purge events by duration
     Delete Device By Name ${deviceName}
+    Set Test Variable  ${PURGE_EXECUTE}  ${0}
 
 No Purge Log Found in ${service}
-    ${logs}  Get Log in ${service}
-    Should Not Contain  ${logs}  purge events by duration
+    Get Log in core-data
+    Should Not Contain  ${service_log}  purge events by duration
     Delete Device By Name ${deviceName}
+    Set Test Variable  ${PURGE_EXECUTE}  ${1}
 
 Get Log in ${service}
     ${current_time}  Get current epoch time
@@ -93,12 +115,10 @@ Get Log in ${service}
     ${logs}  Run Process  ${WORK_DIR}/TAF/utils/scripts/${DEPLOY_TYPE}/query-docker-logs.sh ${service} ${timestamp}
              ...     shell=True  stderr=STDOUT  output_encoding=UTF-8  timeout=5s
     Log  ${logs.stdout}
-    RETURN  ${logs.stdout}
+    Set Test Variable  ${service_log}  ${logs.stdout}
 
 Create Events With AutoEvent Interval ${interval}
     Create AutoEvent Device  ${interval}  false  ${PREFIX}_GenerateDeviceValue_INT8_RW
     Sleep  1s
     Set To Dictionary    ${Device}[0][device][autoEvents][0]  interval=1s
     Update Devices ${Device}
-    Query all events
-    Get Log in core-data

--- a/TAF/testScenarios/integrationTest/UC_scheduler/scheduler.robot
+++ b/TAF/testScenarios/integrationTest/UC_scheduler/scheduler.robot
@@ -4,7 +4,8 @@ Resource        TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
 Resource        TAF/testCaseModules/keywords/core-data/coreDataAPI.robot
 Resource        TAF/testCaseModules/keywords/support-scheduler/supportSchedulerAPI.robot
 Suite Setup     Run keywords   Setup Suite
-...                             AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+                ...      AND  Run Keyword if  $SECURITY_SERVICE_NEEDED == 'true'  Get Token
+                ...      AND  Delete all events by age
 Suite Teardown  Run Teardown Keywords
 
 *** Variables ***


### PR DESCRIPTION
Closes #930 
- disable query reading total count when offset=-1
- Fix script error for core-data retention

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->