### PR TITLE
fix: Remove Event ID Conflict test

### DIFF
--- a/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
+++ b/TAF/testCaseModules/keywords/device-sdk/deviceServiceAPI.robot
@@ -128,7 +128,10 @@ Create events by get device command
         ${random_command}  Get random "commandName" from "${data_type_skip_write_only}"
         Invoke Get command with params ds-pushevent=true by device ${device_name} and command ${random_command}
     END
-    Wait Until Keyword Succeeds  2x  500ms  Query all events
-    should be equal as integers  ${response}  200
+    FOR  ${INDEX}  IN RANGE  3
+        Query all events
+        Exit For Loop If    ${content}[totalCount] != 0
+        Sleep  500ms
+    END
     ${events_length}=   GET LENGTH  ${content}[events]
     run keyword if  ${events_length} == 0  fail  Events didn't create before clean up

--- a/TAF/testScenarios/functionalTest/API/core-data/event/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-data/event/POST-negative.robot
@@ -10,15 +10,7 @@ ${SUITE}          Core-Data Event POST Negative Testcases
 ${LOG_FILE_PATH}  ${WORK_DIR}/TAF/testArtifacts/logs/core-data-post-negative.log
 
 *** Test Cases ***
-ErrEventPOST001 - Create events fails (Event ID Conflict)
-    Given Generate Event Sample  Event  Device-Test-001  Profile-Test-001  Command-Test-001  Simple Reading  Simple Float Reading
-    And Create Event With Service-Test-001 And Profile-Test-001 And Device-Test-001 And Command-Test-001
-    When Create Event With Id Conflict
-    Then Should Return Status Code "409"
-    And Should Return Content-Type "application/json"
-    And Response Time Should Be Less Than "${default_response_time_threshold}"ms
-
-ErrEventPOST002 - Create events fails (Bad Events)
+ErrEventPOST001 - Create events fails (Bad Events)
     ${bad_property}=  Create List  no_deviceName  no_profileName  no_sourceName  no_origin  no_readings  no_id  bad_id
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Event With ${property}
@@ -28,7 +20,7 @@ ErrEventPOST002 - Create events fails (Bad Events)
          And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     END
 
-ErrEventPOST003 - Create events fails (Bad Simple Readings)
+ErrEventPOST002 - Create events fails (Bad Simple Readings)
     ${bad_property}=  Create List  no_deviceName  no_resourceName  no_profileName  no_origin  no_valueType  bad_valueType  no_value
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Simple Reading With ${property}
@@ -38,7 +30,7 @@ ErrEventPOST003 - Create events fails (Bad Simple Readings)
          And Response Time Should Be Less Than "${default_response_time_threshold}"ms
     END
 
-ErrEventPOST004 - Create events fails (Bad Binary Readings)
+ErrEventPOST003 - Create events fails (Bad Binary Readings)
     ${bad_property}=  Create List  no_mediaType  no_valueType
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Binary Reading With ${property}
@@ -49,12 +41,6 @@ ErrEventPOST004 - Create events fails (Bad Binary Readings)
     END
 
 *** Keywords ***
-Create Event With Id Conflict
-    ${exist_id}=  Set Variable  ${id}
-    Generate Event Sample  Event With Tags  Device-Test-001  Profile-Test-001  Command-Test-001  Simple Reading
-    Set to dictionary  ${event}[event]  id=${exist_id}
-    Create Event With Service-Test-001 And Profile-Test-001 And Device-Test-001 And Command-Test-001
-
 Generate Bad Event With ${property}
     Generate Event Sample  Event  Device-Test-002  Profile-Test-002  Command-Test-002  Simple Reading
     ${no_property}=  Fetch From Right  ${property}  no_


### PR DESCRIPTION
Closes #943 
Remove Event ID Conflict test
Update keyword to avoid time issue for scheduler test fail

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->