### PR TITLE
feat: Implement bidirectional DataTransform integration tests with Modbus

### DIFF
--- a/TAF/config/device-modbus/sample_profile.yaml
+++ b/TAF/config/device-modbus/sample_profile.yaml
@@ -241,11 +241,12 @@ deviceResources:
     minimum: 0
     maximum: 4294967295
     defaultValue: "device uINT32 value"
+    shift: -16
 -
   name: "Modbus_DeviceValue_UINT32_R"
   description: "Generate device uINT32 value"
   attributes:
-    { primaryTable: "INPUT_REGISTERS", startingAddress: 47 }
+    { primaryTable: "HOLDING_REGISTERS", startingAddress: 45 }
   properties:
     valueType: "UINT32"
     readWrite: "R"
@@ -256,7 +257,7 @@ deviceResources:
   name: "Modbus_DeviceValue_UINT32_W"
   description: "Generate device uINT32 value"
   attributes:
-    { primaryTable: "HOLDING_REGISTERS", startingAddress: 49 }
+    { primaryTable: "HOLDING_REGISTERS", startingAddress: 45 }
   properties:
     valueType: "UINT32"
     readWrite: "W"


### PR DESCRIPTION
Closed #962 
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->
Added integration test cases to verify bidirectional behavior of DataTransform when the shift field is set. The tests cover:
- RW (with shift) write + R (no shift) read → verify transform on write only
- W (no shift) write + RW (with shift) read → verify transform on read only
- One control case with DataTransform: false to ensure no transformation

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->