### PR TITLE
fix: Update incorrect field name in trigger_data.json

### DIFF
--- a/TAF/testCaseModules/keywords/support-scheduler/supportSchedulerAPI.robot
+++ b/TAF/testCaseModules/keywords/support-scheduler/supportSchedulerAPI.robot
@@ -151,18 +151,6 @@ Trigger Job By Name
     Set Response to Test Variables  ${resp}
     Run Keyword If  ${response} != 202  log to console  ${content}
 
-Create A Job
-    ${job}  General A Job Sample  INTERVAL  30s  REST  http://edgex-core-metadata:59881/api/v3/ping  GET
-    ${currentTime}  Get Current Milliseconds Epoch Time
-    ${startTime}  Evaluate  ${currentTime}-1000
-    ${endTime}  Evaluate  ${currentTime}+6000
-    Set Test Variable  ${job_name}  trigger-manual
-    Generate Multiple Job  ${job}
-    Set To Dictionary  ${jobs}[0][scheduleJob]  name=${job_name}
-    Set To Dictionary  ${jobs}[0][scheduleJob][definition]  startTimestamp=${startTime}
-    Set To Dictionary  ${jobs}[0][scheduleJob][definition]  endTimestamp=${endTime}
-    Create Jobs  ${jobs}
-
 ## Query Schedule Action Record
 Query Schedule Action Record By Job Name
     [Arguments]  ${name}

--- a/TAF/testData/app-service/trigger_data.json
+++ b/TAF/testData/app-service/trigger_data.json
@@ -16,7 +16,7 @@
           "deviceName": "Random-Integer-Device",
           "value": "123",
           "origin": 1540855006469,
-          "ValueType": "Int32",
+          "valueType": "Int32",
           "id": "82eb2e26-0f24-48aa-ae4c-de9dac3fb920"
         }
       ]

--- a/TAF/testScenarios/functionalTest/API/support-scheduler/job/POST-trigger.robot
+++ b/TAF/testScenarios/functionalTest/API/support-scheduler/job/POST-trigger.robot
@@ -49,3 +49,15 @@ Create A Job Which startTimestamp Is Not Arrived Yet
     Set To Dictionary  ${jobs}[0][scheduleJob][definition]  startTimestamp=${startTime}
     Set To Dictionary  ${jobs}[0][scheduleJob][definition]  endTimestamp=${endTime}
     Create Jobs  ${jobs}
+
+Create A Job
+    # Setting the interval to 300s ensures the job can only be triggered manually before the test is completed.
+    ${job}  General A Job Sample  INTERVAL  300s  REST  http://edgex-core-metadata:59881/api/v3/ping  GET
+    ${currentTime}  Get Current Milliseconds Epoch Time
+    ${startTime}  Evaluate  ${currentTime}-1000
+    Set Test Variable  ${job_name}  trigger-manual
+    Generate Multiple Job  ${job}
+    Set To Dictionary  ${jobs}[0][scheduleJob]  name=${job_name}
+    Set To Dictionary  ${jobs}[0][scheduleJob][definition]  startTimestamp=${startTime}
+    Remove From Dictionary    ${jobs}[0][scheduleJob][definition]    endTimestamp
+    Create Jobs  ${jobs}


### PR DESCRIPTION
- Update SchedulerJobTriggerPOST001 to allow only manual triggering job during the test.
- Update incorrect field name in trigger_data.json

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->