### PR TITLE
fix: Update event POST test for optioanl profile name

### DIFF
--- a/TAF/testScenarios/functionalTest/API/core-data/event/POST-negative.robot
+++ b/TAF/testScenarios/functionalTest/API/core-data/event/POST-negative.robot
@@ -21,7 +21,7 @@ ErrEventPOST001 - Create events fails (Bad Events)
     END
 
 ErrEventPOST002 - Create events fails (Bad Simple Readings)
-    ${bad_property}=  Create List  no_deviceName  no_resourceName  no_profileName  no_origin  no_valueType  bad_valueType  no_value
+    ${bad_property}=  Create List  no_deviceName  no_resourceName  no_origin  no_valueType  bad_valueType  no_value
     FOR  ${property}  IN  @{bad_property}
          Given Generate Bad Simple Reading With ${property}
          And Create Event With Service-Test-002 And Profile-Test-002 And Device-Test-002 And Command-Test-002


### PR DESCRIPTION
Close #982 
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->
Update test since reading profileName is optional now.

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->